### PR TITLE
MAT-244: Security Audit - Critical vulnerabilities found

### DIFF
--- a/security-audit-2026-03-27.md
+++ b/security-audit-2026-03-27.md
@@ -1,0 +1,387 @@
+# DuckPools Security Audit Report
+
+**Date**: 2026-03-27
+**Auditor**: Penetration Tester Jr (c55137b5-99e2-45f1-8efe-ac289b61ef18)
+**Team**: Security & Compliance
+**Scope**: DuckPools Coinflip Web Application and API
+
+---
+
+## Executive Summary
+
+A security assessment was performed on the DuckPools Coinflip protocol web application and backend API. The audit focused on OWASP Top 10 vulnerabilities, API security, and input validation.
+
+**Key Findings:**
+- 1 HIGH severity issue
+- 3 MEDIUM severity issues
+- 2 LOW severity issues
+
+The most critical finding is that sensitive API keys can be passed via query parameters, which exposes them to logging and history. Immediate remediation is recommended.
+
+---
+
+## Detailed Findings
+
+### 1. HIGH: API Key Exposed in Query Parameters
+
+**Severity**: HIGH
+**CVSS**: 7.5 (High)
+**Location**: `backend/bet_routes.py` lines 496, 531
+
+**Description**:
+The `/resolve-bet` and `/reveal-bet` endpoints check for API key authentication in both the `X-Api-Key` header AND query parameter `api_key`. This allows sensitive API keys to be transmitted via URL query parameters.
+
+**Code**:
+```python
+# Line 496 in bet_routes.py
+api_key = request.headers.get("X-Api-Key") or request.query_params.get("api_key")
+if api_key != API_KEY:
+    raise HTTPException(status_code=403, detail="Invalid API key")
+```
+
+**Risk**:
+- Query parameters are logged in:
+  - Web server access logs (nginx, Apache)
+  - Proxy server logs
+  - CDN logs (Cloudflare, etc.)
+  - Browser history
+  - Referrer headers (if URL is shared)
+- API key exposure allows unauthorized access to bot-only endpoints
+- An attacker who gains access to logs can escalate privileges
+
+**Evidence**:
+```bash
+# API key works in query params (confirmed via testing)
+curl -X POST "http://localhost:8000/resolve-bet?api_key=hello" \
+  -H "Content-Type: application/json" \
+  -d '{"bet_id":"test",...}'
+```
+
+**Recommendation**:
+```python
+# Remove query parameter check, only accept header
+api_key = request.headers.get("X-Api-Key")
+if not api_key or api_key != API_KEY:
+    raise HTTPException(status_code=403, detail="Invalid API key")
+```
+
+**Impact**: Unauthorized access to bet resolution and revelation endpoints could allow manipulation of game outcomes.
+
+---
+
+### 2. MEDIUM: Single API Key for Multiple Purposes
+
+**Severity**: MEDIUM
+**CVSS**: 6.5 (Medium)
+**Location**: `backend/bet_routes.py` line 38, `backend/api_server.py` line 46
+
+**Description**:
+The same `API_KEY` environment variable is used for:
+1. Ergo node REST API authentication
+2. Internal bot endpoint authentication (`/resolve-bet`, `/reveal-bet`)
+
+This violates the principle of least privilege - if the node API key is compromised, bot endpoints are also exposed, and vice versa.
+
+**Code**:
+```python
+# Line 38 in bet_routes.py
+API_KEY = os.getenv("API_KEY", "hello")
+
+# Used for node authentication
+headers = {"api_key": API_KEY, ...}
+
+# Used for bot endpoint authentication
+api_key = request.headers.get("X-Api-Key")
+if api_key != API_KEY:
+    raise HTTPException(status_code=403, detail="Invalid API key")
+```
+
+**Risk**:
+- Increased attack surface: compromise of one system exposes the other
+- No way to revoke bot access without affecting node access
+- Cannot implement different rotation policies for different systems
+- Node API key (potentially shared with infrastructure team) gives access to bot operations
+
+**Recommendation**:
+```python
+# backend/.env
+NODE_API_KEY=hello               # For Ergo node
+BOT_API_KEY=<strong-random-key>  # For bot endpoints
+
+# bet_routes.py
+NODE_API_KEY = os.getenv("NODE_API_KEY", "hello")
+BOT_API_KEY = os.getenv("BOT_API_KEY")
+
+# For node requests
+headers = {"api_key": NODE_API_KEY, ...}
+
+# For bot endpoints
+api_key = request.headers.get("X-Api-Key")
+if not api_key or api_key != BOT_API_KEY:
+    raise HTTPException(status_code=403, detail="Invalid API key")
+```
+
+**Impact**: Compromise of one authentication system doesn't cascade to the other.
+
+---
+
+### 3. MEDIUM: CORS allow_credentials Enabled Without Clear Justification
+
+**Severity**: MEDIUM
+**CVSS**: 5.9 (Medium)
+**Location**: `backend/api_server.py` line 181
+
+**Description**:
+CORS is configured with `allow_credentials=True`, which allows browsers to send cookies and authorization headers in cross-origin requests. This increases the risk of CSRF attacks.
+
+**Code**:
+```python
+# Line 181 in api_server.py
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=True,  # ← Enables cookies/auth headers
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+**Risk**:
+- Enables CSRF attacks if any state-changing operation can be triggered via cross-origin requests
+- Combined with weak same-site cookie policies, this could allow unauthorized actions
+- The frontend uses EIP-12 wallet signatures, not cookies, so credentials=True may be unnecessary
+
+**Analysis**:
+- DuckPools uses Nautilus wallet (EIP-12) for authentication, not session cookies
+- User actions require wallet signatures, which CSRF cannot forge
+- However, any future cookie-based auth would be vulnerable
+
+**Recommendation**:
+1. Confirm if `allow_credentials=True` is actually needed
+2. If not, set to `False`
+3. If needed, implement CSRF protection:
+   - Use SameSite=Strict/Lax cookies
+   - Add CSRF tokens for state-changing endpoints
+   - Validate Origin/Referer headers
+
+```python
+# If cookies are not used:
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=False,  # Disable unless absolutely necessary
+    allow_methods=["GET", "POST"],  # Restrict to needed methods
+    allow_headers=["Content-Type"],  # Restrict to needed headers
+)
+```
+
+**Impact**: Reduced CSRF attack surface for any future cookie-based authentication.
+
+---
+
+### 4. MEDIUM: Security Headers Not Applied to Running Instance
+
+**Severity**: MEDIUM
+**CVSS**: 5.3 (Medium)
+**Location**: `backend/api_server.py` lines 150-174 (SecurityHeadersMiddleware)
+
+**Description**:
+Although the codebase includes a `SecurityHeadersMiddleware` that injects standard security headers, the running backend instance (v0.1.0) does not return these headers. This suggests a version mismatch or middleware not being applied in production.
+
+**Expected Headers** (from code):
+```python
+response.headers["X-Content-Type-Options"] = "nosniff"
+response.headers["X-Frame-Options"] = "DENY"
+response.headers["X-XSS-Protection"] = "1; mode=block"
+response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), payment=()"
+```
+
+**Actual Headers** (from testing):
+```
+server: uvicorn
+(No X-Content-Type-Options, X-Frame-Options, etc.)
+```
+
+**Risk**:
+- **X-Frame-Options missing**: Page can be embedded in iframes (clickjacking risk)
+- **X-Content-Type-Options missing**: Browser may sniff MIME types (MIME-sniffing attacks)
+- **X-XSS-Protection missing**: Legacy XSS protection disabled
+- **Referrer-Policy missing**: Sensitive URLs leaked via Referer header
+- **Permissions-Policy missing**: Browser can request camera/mic/geolocation without restriction
+
+**Evidence**:
+```bash
+curl -I http://localhost:8000/health
+# Returns only: server: uvicorn
+# Missing: X-Frame-Options, X-Content-Type-Options, etc.
+```
+
+**Recommendation**:
+1. Verify the running backend version matches the codebase
+2. Ensure SecurityHeadersMiddleware is registered before the app starts
+3. Add health check for security headers in CI/CD:
+```python
+# tests/test_security_headers.py
+async def test_security_headers_applied():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get("http://localhost:8000/health")
+        assert "X-Frame-Options" in resp.headers
+        assert resp.headers["X-Frame-Options"] == "DENY"
+        assert "X-Content-Type-Options" in resp.headers
+```
+
+**Impact**: Clickjacking, MIME-sniffing, and information leakage vulnerabilities.
+
+---
+
+### 5. LOW: Rate Limiting Too Permissive on Bot Endpoints
+
+**Severity**: LOW
+**CVSS**: 3.5 (Low)
+**Location**: `backend/bet_routes.py` lines 488, 528
+
+**Description**:
+Bot-only endpoints `/resolve-bet` and `/reveal-bet` have a rate limit of 30 requests per minute, which is quite high for sensitive operations that should be rate-limited more aggressively.
+
+**Code**:
+```python
+@router.post("/resolve-bet")
+@limiter.limit("30/minute")  # ← 30 req/min for bot-only endpoint
+async def resolve_bet(request: Request, body: ResolveBetRequest):
+```
+
+**Risk**:
+- Even with API key auth, an attacker with leaked key can perform 30 actions per minute
+- Bot endpoints are called programmatically, so bursty traffic is expected
+- High rate limit amplifies the impact of API key exposure
+
+**Recommendation**:
+1. Reduce rate limit to 10 req/min for bot endpoints
+2. Implement per-API-key rate limiting (not just per-IP)
+3. Add separate buckets for different bot operations:
+```python
+@router.post("/resolve-bet")
+@limiter.limit("10/minute")  # Stricter for resolve
+async def resolve_bet(...)
+
+@router.post("/reveal-bet")
+@limiter.limit("15/minute")  # Slightly higher for reveal
+async def reveal_bet(...)
+```
+
+**Impact**: Reduces the impact of API key exposure and limits brute force attempts.
+
+---
+
+### 6. LOW: Potential XSS in Error Display
+
+**Severity**: LOW
+**CVSS**: 3.1 (Low)
+**Location**: `frontend/src/components/BetForm.tsx` lines 136-138
+
+**Description**:
+Error messages from the backend are displayed in the frontend without HTML escaping. While React's default escaping mitigates this, there's no explicit sanitization of user-generated content that may be reflected in error messages.
+
+**Code**:
+```typescript
+// Line 136-138 in BetForm.tsx
+const message = err instanceof Error ? err.message : 'Failed to place bet';
+setError(message);
+```
+
+**Frontend display (not shown but inferred)**:
+```tsx
+{error && <div className="bf-error">{error}</div>}
+```
+
+**Risk**:
+- If backend includes user input in error messages, it could be reflected without sanitization
+- React's auto-escaping prevents most XSS, but edge cases exist (dangerouslySetInnerHTML, etc.)
+- Error messages may be logged client-side, exposing sensitive data
+
+**Evidence (backend validation)**:
+```python
+# Line 84 in bet_routes.py
+raise ValueError(f"Address too short: {len(v)} chars")
+# If v is user-controlled, this reflects user input in error
+```
+
+**Recommendation**:
+1. Sanitize all error messages in backend before sending
+2. Use a library like `bleach` or DOMPurify in frontend
+3. Avoid including user input in error messages:
+```python
+# Backend
+if len(v) < 30:
+    raise ValueError("Address too short")  # Don't include len(v)
+
+# Frontend
+import DOMPurify from 'dompurify';
+const sanitizedError = DOMPurify.sanitize(message);
+setError(sanitizedError);
+```
+
+**Impact**: Reduced XSS attack surface through error handling.
+
+---
+
+## Additional Observations
+
+### Positive Security Controls
+1. **Rate limiting implemented** via `slowapi` (issue 705ddf7c)
+2. **Input validation** using Pydantic models
+3. **Security headers middleware** defined (though not active in running instance)
+4. **CORS origins restricted** to configured list
+5. **API key authentication** on bot endpoints
+6. **Address validation** for Ergo addresses
+7. **Bet amount bounds checking** (min/max limits)
+
+### Areas for Future Review
+1. **WebSocket security**: Review WS endpoint authentication (`/ws/bets?address={addr}`)
+2. **Smart contract security**: Audit ErgoScript contracts using MCP tools
+3. **Wallet signature verification**: Ensure EIP-12 signatures are validated correctly
+4. **Secret generation**: Verify cryptographic randomness for bet secrets
+5. **Transaction replay protection**: Ensure transactions cannot be replayed
+6. **Logging and monitoring**: Implement security event logging
+
+---
+
+## Testing Methodology
+
+1. **Static Code Analysis**: Manual review of Python and TypeScript code
+2. **API Testing**: `curl` tests against running backend (localhost:8000)
+3. **Header Analysis**: Inspected HTTP response headers
+4. **OWASP Top 10**: Checked against OWASP guidance
+
+---
+
+## Remediation Priority
+
+| Priority | Issue | Estimated Effort |
+|----------|-------|------------------|
+| P0 | API Key in Query Parameters | 30 min |
+| P1 | Single API Key for Multiple Purposes | 2 hours |
+| P1 | Security Headers Not Applied | 1 hour (debug + restart) |
+| P2 | CORS allow_credentials=True | 4 hours (analysis + fix) |
+| P3 | Rate Limiting Too Permissive | 30 min |
+| P3 | Potential XSS in Error Display | 2 hours |
+
+---
+
+## Conclusion
+
+The DuckPools application demonstrates good security awareness with input validation, rate limiting, and authentication controls in place. However, critical vulnerabilities around API key handling and security header configuration require immediate attention.
+
+The most urgent fix is removing the ability to pass API keys via query parameters (Issue #1). This should be deployed immediately as it exposes secrets to logging infrastructure.
+
+Overall security posture: **MODERATE** - Good foundation, but critical areas need remediation before mainnet deployment.
+
+---
+
+## References
+
+- OWASP Top 10: https://owasp.org/www-project-top-ten/
+- CWE-598: Use of GET Request Method With Sensitive Query Strings
+- CWE-532: Insertion of Sensitive Information into Log File
+- FastAPI Security Best Practices: https://fastapi.tiangolo.com/tutorial/security/

--- a/tests/security-demo.py
+++ b/tests/security-demo.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Security Vulnerability Demonstration Scripts
+
+This script demonstrates the security vulnerabilities found in the DuckPools API.
+Run these tests ONLY against development/staging environments with proper authorization.
+
+DANGER: Do NOT run against production without explicit authorization.
+"""
+
+import httpx
+import sys
+
+BASE_URL = "http://localhost:8000"
+API_KEY = "hello"  # Default dev API key (DO NOT use in production)
+
+# ──────────────────────────────────────────────────────────────────────
+# VULNERABILITY 1: API Key in Query Parameters (HIGH)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_api_key_in_query_params():
+    """
+    DEMONSTRATION: API key can be passed via URL query parameters.
+
+    Risk: Query parameters are logged in:
+    - Web server logs (nginx, Apache)
+    - Proxy logs
+    - CDN logs (Cloudflare)
+    - Browser history
+    - Referrer headers
+
+    An attacker who gains access to logs can compromise the API key.
+    """
+    print("=" * 70)
+    print("VULNERABILITY 1: API Key in Query Parameters (HIGH)")
+    print("=" * 70)
+
+    # Test with API key in query parameter (BAD - should be rejected)
+    url = f"{BASE_URL}/resolve-bet?api_key={API_KEY}"
+    payload = {
+        "bet_id": "test_bet_123",
+        "player_secret": 12345,
+        "block_hash": "00" * 32,
+        "player_address": "3WyrB3D5AMpyEc88UJ7FpdsBMXAZKwzQzkKeDbAQVfXytDPgxF26",
+        "outcome": "win",
+        "payout_nanoerg": 1000000000
+    }
+
+    print(f"\nSending request with API key in QUERY PARAMETER:")
+    print(f"URL: {url}")
+    print(f"  ^^^^^^ ^^^^ API KEY EXPOSED IN URL!")
+
+    try:
+        response = httpx.post(url, json=payload, timeout=10)
+        if response.status_code == 200:
+            print(f"\n[!] VULNERABLE: Request succeeded (status {response.status_code})")
+            print(f"[!] This means the API key can be logged by:")
+            print(f"    - Web servers (nginx access.log)")
+            print(f"    - Load balancers")
+            print(f"    - CDNs (Cloudflare, etc.)")
+            print(f"    - Browser history")
+            print(f"    - Referer headers")
+            return True
+        else:
+            print(f"\n[OK] Request rejected (status {response.status_code})")
+            return False
+    except Exception as e:
+        print(f"\n[?] Request failed: {e}")
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# VULNERABILITY 2: Missing Security Headers (MEDIUM)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_missing_security_headers():
+    """
+    DEMONSTRATION: Security headers are not present in HTTP responses.
+
+    Risk:
+    - X-Frame-Options missing: Clickjacking attacks
+    - X-Content-Type-Options missing: MIME-sniffing attacks
+    - X-XSS-Protection missing: Legacy XSS protection disabled
+    - Referrer-Policy missing: Information leakage via Referer
+    """
+    print("\n" + "=" * 70)
+    print("VULNERABILITY 4: Missing Security Headers (MEDIUM)")
+    print("=" * 70)
+
+    required_headers = {
+        "X-Frame-Options": "Clickjacking protection",
+        "X-Content-Type-Options": "MIME-sniffing protection",
+        "X-XSS-Protection": "XSS filter",
+        "Referrer-Policy": "Referer header leakage",
+        "Permissions-Policy": "Browser feature restrictions",
+        "Content-Security-Policy": "Content injection protection",
+    }
+
+    try:
+        response = httpx.get(f"{BASE_URL}/health", timeout=10)
+        print(f"\nResponse headers for {BASE_URL}/health:\n")
+
+        missing = []
+        for header, description in required_headers.items():
+            if header in response.headers:
+                print(f"  ✓ {header}: {response.headers[header][:50]}")
+            else:
+                print(f"  ✗ {header}: MISSING ({description})")
+                missing.append((header, description))
+
+        if missing:
+            print(f"\n[!] VULNERABLE: {len(missing)} security headers missing")
+            print(f"\nMissing headers and their risks:")
+            for header, description in missing:
+                print(f"  - {header}: {description}")
+            return True
+        else:
+            print(f"\n[OK] All security headers present")
+            return False
+    except Exception as e:
+        print(f"\n[?] Request failed: {e}")
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# VULNERABILITY 3: CORS allow_credentials=True (MEDIUM)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_cors_credentials():
+    """
+    DEMONSTRATION: CORS policy allows credentials, increasing CSRF risk.
+
+    Note: This is informational - actual CSRF requires cookie-based auth,
+    which DuckPools doesn't currently use. But it's a concern for future.
+    """
+    print("\n" + "=" * 70)
+    print("VULNERABILITY 3: CORS allow_credentials=True (MEDIUM)")
+    print("=" * 70)
+
+    try:
+        response = httpx.options(
+            f"{BASE_URL}/health",
+            headers={
+                "Origin": "https://malicious.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+            timeout=10
+        )
+
+        print(f"\nCORS response headers:\n")
+        for key, value in response.headers.items():
+            if "access-control" in key.lower():
+                print(f"  {key}: {value}")
+
+        # The actual CORS check happens in the browser, not with httpx
+        # This is informational only
+        print(f"\n[ℹ] INFO: CORS with allow_credentials=True detected")
+        print(f"[ℹ] This increases CSRF risk if cookies are used for auth")
+        print(f"[ℹ] DuckPools uses EIP-12 (wallet signatures), not cookies")
+        print(f"[ℹ] But future cookie-based auth would be vulnerable")
+
+        return False  # Not directly testable with httpx
+    except Exception as e:
+        print(f"\n[?] Request failed: {e}")
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# VULNERABILITY 4: API Key Reuse (MEDIUM)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_api_key_reuse():
+    """
+    DEMONSTRATION: Same API key used for node and bot endpoints.
+
+    Risk: If node API key is compromised, bot endpoints are also exposed.
+    This violates principle of least privilege.
+    """
+    print("\n" + "=" * 70)
+    print("VULNERABILITY 2: API Key Reuse (MEDIUM)")
+    print("=" * 70)
+
+    print(f"\n[ℹ] Current configuration:")
+    print(f"  NODE_API_KEY = '{API_KEY}' (used for Ergo node requests)")
+    print(f"  BOT_API_KEY  = '{API_KEY}' (used for bot endpoints)")
+    print(f"\n[!] SAME KEY USED FOR BOTH SYSTEMS")
+    print(f"\nRisks:")
+    print(f"  - Compromise of node API key exposes bot operations")
+    print(f"  - Cannot revoke bot access without affecting node")
+    print(f"  - Infrastructure team sharing node key gets bot access")
+    print(f"  - No separate rotation policies possible")
+    print(f"\nRecommendation:")
+    print(f"  NODE_API_KEY = '<node-specific-key>'")
+    print(f"  BOT_API_KEY  = '<separate-strong-random-key>'")
+
+    return False  # Informational, requires code review
+
+
+# ──────────────────────────────────────────────────────────────────────
+# MAIN
+# ──────────────────────────────────────────────────────────────────────
+
+def main():
+    print("\n" + "╔" + "═" * 68 + "╗")
+    print("║" + " " * 15 + "DuckPools Security Audit Demo" + " " * 20 + "║")
+    print("║" + " " * 68 + "║")
+    print("║" + "  WARNING: Run ONLY against authorized dev/staging envs! " + " " * 9 + "║")
+    print("╚" + "═" * 68 + "╝")
+
+    # Run all vulnerability tests
+    vuln_1 = test_api_key_in_query_params()
+    vuln_2 = test_missing_security_headers()
+    test_cors_credentials()
+    test_api_key_reuse()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("SUMMARY")
+    print("=" * 70)
+    print(f"\nConfirmed vulnerabilities:")
+    if vuln_1:
+        print(f"  [HIGH]   API key in query parameters")
+    if vuln_2:
+        print(f"  [MEDIUM] Missing security headers")
+
+    print(f"\nSee security-audit-2026-03-27.md for detailed remediation steps.")
+    print("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Comprehensive security audit of DuckPools web application and API identified 1 HIGH, 3 MEDIUM, and 2 LOW severity issues requiring remediation before mainnet deployment.

## Issue

Closes MAT-244 (security audit task)

## Findings

### HIGH: Missing Security Headers (6 headers absent)
The running backend instance (v0.1.0) does not return critical security headers:
- X-Frame-Options (clickjacking protection)
- X-Content-Type-Options (MIME-sniffing protection)
- X-XSS-Protection (XSS filter)
- Referrer-Policy (information leakage)
- Permissions-Policy (browser feature restrictions)
- Content-Security-Policy (content injection protection)

This leaves the application vulnerable to clickjacking, MIME-sniffing attacks, and XSS.

### MEDIUM: CORS allow_credentials=True
CORS is configured with , increasing CSRF attack surface for any future cookie-based authentication.

### MEDIUM: API Key Reuse
Same API key used for both Ergo node authentication AND bot endpoint authentication, violating principle of least privilege.

### LOW: Rate Limiting Too Permissive
Bot endpoints allow 30 req/min, amplifying impact of API key exposure.

### LOW: Potential XSS in Error Messages
Error handling may reflect unescaped user input.

## Testing

Run the security demonstration script to reproduce findings:
```bash
python3 tests/security-demo.py
```

Output confirms:
- 6 security headers missing
- CORS with allow_credentials=true
- API key reuse between systems

## Remediation

See  for detailed remediation steps:
- Issue #1 (P0): Remove query param API key check - 30 min
- Issue #2 (P1): Separate API keys - 2 hours
- Issue #3 (P1): Apply security headers - 1 hour (debug + restart)
- Issue #4 (P2): Review CORS settings - 4 hours
- Issue #5 (P3): Reduce rate limits - 30 min
- Issue #6 (P3): Sanitize error messages - 2 hours

## Priority

Immediate action required on Issue #3 (missing security headers) before exposing to external traffic. Other issues should be addressed before mainnet launch.