### PR TITLE
MAT-223: Fix retry logic and logging in off-chain bot

### DIFF
--- a/off-chain-bot/main.py
+++ b/off-chain-bot/main.py
@@ -23,9 +23,8 @@ from typing import Optional
 
 import httpx
 from tenacity import (
-    before_sleep_log,
     retry,
-    retry_if_exception_type,
+    retry_if_exception,
     stop_after_attempt,
     wait_exponential,
 )
@@ -83,14 +82,24 @@ def get_retry_decorator():
     Returns:
         Configured retry decorator
     """
+
+    def log_retry_attempt(retry_state):
+        """Log retry attempt using structlog."""
+        logger.warning(
+            "api_retry_attempt",
+            attempt_number=retry_state.attempt_number,
+            exception=str(retry_state.outcome.exception()),
+            seconds_since_start=retry_state.seconds_since_start,
+        )
+
     return retry(
         stop=stop_after_attempt(RETRY_MAX_ATTEMPTS),
         wait=wait_exponential(
             multiplier=RETRY_MIN_WAIT_SECONDS,
             max=RETRY_MAX_WAIT_SECONDS,
         ),
-        retry=retry_if_exception_type((httpx.ConnectError, httpx.ConnectTimeout, httpx.TimeoutException, httpx.HTTPStatusError)),
-        before_sleep=before_sleep_log(logger, logging.WARNING),
+        retry=retry_if_exception(is_retryable_error),
+        before_sleep=log_retry_attempt,
         reraise=True,
     )
 


### PR DESCRIPTION
## Summary
Fixed bugs in the off-chain bot retry logic implementation:
- Changed retry decorator to use `retry_if_exception(is_retryable_error)` to properly filter for only 500/502/503 status codes instead of retrying all HTTPStatusError
- Replaced `before_sleep_log` (standard logging) with custom structlog-based logging function `log_retry_attempt`

## Changes
- Updated `get_retry_decorator()` to use `retry_if_exception()` with the `is_retryable_error` function
- Added `log_retry_attempt()` function that logs retry attempts using structlog with context
- Updated tenacity imports: removed `before_sleep_log` and `retry_if_exception_type`, added `retry_if_exception`

## Testing
- Verified code compiles without errors
- Confirmed retry decorator now properly filters retryable errors
- Retry logging now uses structlog instead of standard logging

Closes #223

## Acceptance Criteria
- [x] Node API calls wrapped in retry with backoff (existed, now properly filters errors)
- [x] Graceful shutdown on SIGINT/SIGTERM (existed)
- [x] No unhandled exceptions during transient node errors (fixed - now only retries retryable errors)
- [x] Bot logs each retry attempt (fixed - now uses structlog)