### PR TITLE
MAT-217: E2E Test Plan for Bankroll Monitoring Service

### DIFF
--- a/tests/MAT-217_BANKROLL_TEST_PLAN.md
+++ b/tests/MAT-217_BANKROLL_TEST_PLAN.md
@@ -1,0 +1,518 @@
+# MAT-217: Bankroll Monitoring Service E2E Test Plan
+
+**Issue**: MAT-217  
+**Type**: QA Documentation  
+**Status**: Test Plan (waiting for implementation)  
+**Parent Issue**: MAT-204 (cancelled - bankroll monitoring service)  
+
+## Overview
+
+This document outlines the comprehensive E2E test strategy for the DuckPools bankroll monitoring service. Since MAT-204 (the implementation) is cancelled, this test plan serves as a specification for when the bankroll monitoring feature is re-implemented or when a new implementation is created.
+
+## Test Objectives
+
+Verify that the bankroll monitoring service:
+1. Accurately tracks house wallet balance (ERG + tokens)
+2. Calculates exposure from unresolved bets correctly
+3. Computes max payout capacity accurately
+4. Provides REST API endpoints with real-time data
+5. Handles edge cases and concurrency correctly
+6. Triggers low bankroll alerts at the configured threshold
+
+## Test Environment
+
+### Required Services
+- Ergo node: `http://localhost:9052`
+- Backend API: `http://localhost:8000`
+- Paperclip DB: `127.0.0.1:54329`
+
+### Environment Variables
+```bash
+NODE_URL=http://localhost:9052
+EXPLORER_URL=http://localhost:9052
+HOUSE_ADDRESS=<house-wallet-address>
+COINFLIP_NFT_ID=<coinflip-nft-id>
+API_KEY=<api-key>
+BACKEND_URL=http://localhost:8000
+```
+
+## Test Cases
+
+### TC-001: Basic Bankroll Status Endpoint
+
+**Preconditions**:
+- Backend is running
+- Ergo node is synced
+- House wallet exists with balance
+
+**Steps**:
+1. `GET http://localhost:8000/bankroll/status`
+2. Verify response contains:
+   - `balance` (nanoERG)
+   - `exposure` (nanoERG)
+   - `available` (nanoERG)
+   - `pendingBets` (count)
+   - `lastUpdate` (ISO 8601 timestamp)
+
+**Expected Results**:
+- HTTP 200 OK
+- JSON response with all required fields
+- `balance` matches node API house wallet balance
+- `lastUpdate` is recent (within 10 seconds)
+
+**Verification Method**:
+```bash
+# Compare balance from bankroll endpoint with node API
+curl http://localhost:9052/wallet/balances
+# Should match bankroll/status balance
+```
+
+---
+
+### TC-002: Balance Accuracy - Empty State
+
+**Preconditions**:
+- No pending bets
+- House wallet has known balance
+
+**Steps**:
+1. Check house wallet balance via node API
+2. Call `GET /bankroll/status`
+3. Verify `balance` matches node balance
+4. Verify `exposure = 0`
+5. Verify `available = balance`
+
+**Expected Results**:
+- `balance` == node wallet balance
+- `exposure` == 0
+- `available` == `balance`
+- `pendingBets` == 0
+
+---
+
+### TC-003: Exposure Calculation - Single Bet
+
+**Preconditions**:
+- House wallet has initial balance
+- No pending bets
+
+**Steps**:
+1. Record initial `balance` and `available`
+2. Place a coinflip bet (e.g., 1 ERG)
+3. Wait for PendingBet box creation
+4. Call `GET /bankroll/status`
+5. Verify `exposure` equals bet amount
+6. Verify `available = balance - exposure`
+
+**Expected Results**:
+- `exposure` increases by bet amount
+- `available` decreases by bet amount
+- `balance` unchanged
+- `pendingBets` == 1
+
+---
+
+### TC-004: Exposure Calculation - Multiple Pending Bets
+
+**Preconditions**:
+- House wallet with sufficient balance
+
+**Steps**:
+1. Place 5 coinflip bets (varying amounts: 0.5, 1, 2, 3, 5 ERG)
+2. Do not reveal any bets
+3. Call `GET /bankroll/status`
+4. Verify `exposure` = sum of all 5 bet amounts
+5. Verify `available = balance - exposure`
+
+**Expected Results**:
+- `exposure` = 11.5 ERG (0.5 + 1 + 2 + 3 + 5)
+- `available` = `balance` - 11.5 ERG
+- `pendingBets` == 5
+
+---
+
+### TC-005: Exposure Reduction - Bet Resolution
+
+**Preconditions**:
+- Multiple pending bets exist
+
+**Steps**:
+1. Record current `exposure` and `pendingBets`
+2. Reveal and resolve 2 of the pending bets
+3. Call `GET /bankroll/status`
+4. Verify `exposure` decreased by resolved bet amounts
+5. Verify `pendingBets` decreased by 2
+
+**Expected Results**:
+- `exposure` reflects only unresolved bets
+- `pendingBets` reflects current count
+- `available` updated correctly
+
+---
+
+### TC-006: Max Payout Capacity Calculation
+
+**Preconditions**:
+- House wallet with balance
+- Some pending bets
+
+**Steps**:
+1. Call `GET /bankroll/status`
+2. Calculate expected max payout:
+   - `maxPayout = available - (house_edge * exposure)`
+   - Or verify API returns `maxPayout` field
+3. Attempt to place bet > `maxPayout`
+4. Verify bet is rejected
+
+**Expected Results**:
+- API returns correct max payout capacity
+- Bets exceeding max payout are rejected with clear error
+
+---
+
+### TC-007: On-Chain Balance Verification
+
+**Preconditions**:
+- House wallet with known on-chain balance
+
+**Steps**:
+1. Get house wallet balance via node:
+   ```bash
+   curl http://localhost:9052/wallet/balances
+   ```
+2. Call `GET /bankroll/status`
+3. Get all unspent boxes with COINFLIP_NFT_ID:
+   ```bash
+   curl http://localhost:9052/blockchain/box/unspent/byTokenId/{NFT_ID}
+   ```
+4. Sum all PendingBet box values
+5. Verify:
+   - `balance` from API == wallet balance
+   - `exposure` from API == sum of PendingBet values
+
+**Expected Results**:
+- Perfect match between API and node data
+- No off-by-one errors
+- All pending bets accounted for
+
+---
+
+### TC-008: Low Bankroll Alert Threshold
+
+**Preconditions**:
+- Alert threshold configured (e.g., 100 ERG)
+- House wallet balance > threshold
+
+**Steps**:
+1. Verify no alert present
+2. Place bets until `available` drops below threshold
+3. Monitor for alert trigger
+4. Check for alert via API endpoint or logs
+
+**Expected Results**:
+- Alert triggers when `available` < threshold
+- Alert contains current `available`, `balance`, `exposure`
+- Alert is logged or sent via configured channel
+
+**Verification**:
+```bash
+# Check if alert endpoint exists
+GET /bankroll/alerts
+# Should return active alerts
+```
+
+---
+
+### TC-009: Zero Balance Edge Case
+
+**Preconditions**:
+- House wallet with minimal balance (for test)
+
+**Steps**:
+1. Drain house wallet to near zero (test setup)
+2. Call `GET /bankroll/status`
+3. Verify no crash, returns zeros
+
+**Expected Results**:
+- HTTP 200 OK
+- `balance` == 0 or minimal
+- `exposure` == 0
+- `available` == 0 or negative (handled correctly)
+- No 500 errors
+
+---
+
+### TC-010: Large Balance Scenario (100k+ ERG)
+
+**Preconditions**:
+- Simulated large balance (use testnet)
+
+**Steps**:
+1. Mock or set large balance via test setup
+2. Place multiple bets totaling 50k ERG
+3. Call `GET /bankroll/status`
+4. Verify all calculations correct with large numbers
+
+**Expected Results**:
+- No integer overflow
+- Correct calculations with nanoERG precision
+- Performance acceptable (response < 500ms)
+
+---
+
+### TC-011: Concurrent Bet Resolution During Monitoring
+
+**Preconditions**:
+- Multiple pending bets
+
+**Steps**:
+1. Start loop: call `GET /bankroll/status` 10 times rapidly
+2. During loop, simultaneously resolve 3 bets in background
+3. Verify all API calls return consistent data
+4. Check for race conditions or stale reads
+
+**Expected Results**:
+- No data corruption
+- No duplicate counting
+- Final state correct
+- No race condition errors
+
+**Verification**:
+```python
+# Python test script
+import asyncio
+import aiohttp
+
+async def stress_test():
+    tasks = []
+    for i in range(10):
+        tasks.append(get_bankroll_status())
+    
+    # In parallel, resolve some bets
+    # ...
+    
+    results = await asyncio.gather(*tasks)
+    # Verify consistency
+```
+
+---
+
+### TC-012: API Response Caching
+
+**Preconditions**:
+- Backend with 10s cache configured
+
+**Steps**:
+1. Call `GET /bankroll/status` at t=0
+2. Wait 2 seconds, call again
+3. Verify `lastUpdate` same (cached)
+4. Wait 10 seconds, call again
+5. Verify `lastUpdate` updated (refreshed)
+
+**Expected Results**:
+- Cache respects 10s TTL
+- `lastUpdate` indicates actual data freshness
+- Cache invalidates on bet events
+
+---
+
+### TC-013: Real-time Updates on Bet Events
+
+**Preconditions**:
+- WebSocket or event-driven updates configured
+
+**Steps**:
+1. Open WebSocket connection to bankroll updates
+2. Place bet
+3. Verify immediate push update
+4. Reveal bet
+5. Verify immediate push update
+
+**Expected Results**:
+- WebSocket receives updates on bet events
+- Updates contain new `balance`, `exposure`, `available`
+- Latency < 1 second
+
+**Verification**:
+```javascript
+// WebSocket test
+const ws = new WebSocket('ws://localhost:8000/bankroll/stream');
+
+ws.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  console.log('Bankroll update:', data);
+  // Verify data fields
+};
+```
+
+---
+
+### TC-014: Error Handling - Node API Down
+
+**Preconditions**:
+- Ergo node running
+
+**Steps**:
+1. Stop Ergo node
+2. Call `GET /bankroll/status`
+3. Verify appropriate error response
+
+**Expected Results**:
+- HTTP 503 Service Unavailable or 502 Bad Gateway
+- Clear error message
+- No crash
+- Automatic retry when node returns
+
+---
+
+### TC-015: Error Handling - Invalid Token ID
+
+**Preconditions**:
+- Invalid COINFLIP_NFT_ID configured
+
+**Steps**:
+1. Set COINFLIP_NFT_ID to invalid value
+2. Restart backend
+3. Call `GET /bankroll/status`
+4. Verify graceful handling
+
+**Expected Results**:
+- Returns balance correctly
+- `exposure` = 0 (no boxes found)
+- No crash
+- Clear warning in logs
+
+---
+
+## Test Automation Plan
+
+### Test File Structure
+```
+tests/
+├── test_bankroll_monitoring.py  # Main test suite
+└── utils/
+    └── bankroll_helpers.py      # Helper functions
+```
+
+### Key Test Functions
+
+```python
+# test_bankroll_monitoring.py
+
+import pytest
+import httpx
+import asyncio
+from decimal import Decimal
+
+async def test_bankroll_status_basic():
+    """TC-001: Basic bankroll status endpoint"""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{BACKEND_URL}/bankroll/status",
+            headers={"api_key": API_KEY},
+            timeout=10.0
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "balance" in data
+        assert "exposure" in data
+        assert "available" in data
+        assert "pendingBets" in data
+        assert "lastUpdate" in data
+
+
+async def test_exposure_single_bet():
+    """TC-003: Exposure calculation for single bet"""
+    # ... implementation
+
+
+async def test_on_chain_balance_verification():
+    """TC-007: Verify balance matches node API"""
+    # ... implementation
+
+
+async def test_concurrent_bet_resolution():
+    """TC-011: Test race conditions during concurrent operations"""
+    # ... implementation
+```
+
+### Helper Functions
+
+```python
+# utils/bankroll_helpers.py
+
+async def get_house_wallet_balance(node_url: str, api_key: str) -> int:
+    """Get house wallet balance from Ergo node"""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{node_url}/wallet/balances",
+            headers={"api_key": api_key}
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data[0]["balance"]  # nanoERG
+
+
+async def get_pending_bet_boxes(node_url: str, nft_id: str) -> list:
+    """Get all PendingBet boxes by token ID"""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{node_url}/blockchain/box/unspent/byTokenId/{nft_id}"
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def calculate_exposure_from_boxes(boxes: list) -> int:
+    """Calculate exposure from PendingBet box values"""
+    return sum(box["value"] for box in boxes)
+```
+
+## Success Criteria
+
+All tests pass:
+- [ ] TC-001: Basic endpoint
+- [ ] TC-002: Empty state
+- [ ] TC-003: Single bet exposure
+- [ ] TC-004: Multiple bets exposure
+- [ ] TC-005: Exposure reduction
+- [ ] TC-006: Max payout capacity
+- [ ] TC-007: On-chain verification
+- [ ] TC-008: Alert threshold
+- [ ] TC-009: Zero balance edge case
+- [ ] TC-010: Large balance scenario
+- [ ] TC-011: Concurrent operations
+- [ ] TC-012: API caching
+- [ ] TC-013: Real-time updates
+- [ ] TC-014: Node API error handling
+- [ ] TC-015: Invalid token handling
+
+## Blocking Issues
+
+- **MAT-204 is cancelled**: No bankroll monitoring implementation exists
+- Need new issue for bankroll monitoring implementation
+- Test automation can be written once implementation exists
+
+## Next Steps
+
+1. **Immediate**: Submit this test plan as PR for review
+2. **When MAT-204 is re-opened or replaced**:
+   - Implement test automation in `tests/test_bankroll_monitoring.py`
+   - Run full test suite
+   - Post results as comment on this issue
+   - File bug reports for any failures
+
+## Resources
+
+- MAT-204: [Cancelled] Bankroll monitoring service implementation
+- Backend API: `http://localhost:8000`
+- Ergo Node API: `http://localhost:9052`
+- Coinflip NFT ID: `{COINFLIP_NFT_ID}`
+
+---
+
+**Prepared by**: QA Tester Jr (780f04f8-c43c-496e-a126-6a95acb76aae)  
+**Date**: 2026-03-28  
+**Status**: Test Plan Complete - Waiting for Implementation

--- a/tests/test_bankroll_monitoring.py
+++ b/tests/test_bankroll_monitoring.py
@@ -1,0 +1,511 @@
+"""
+DuckPools - Bankroll Monitoring Service Tests
+
+End-to-end tests for the bankroll monitoring service:
+- Balance accuracy (matches on-chain data)
+- Exposure calculation (sum of unresolved bets)
+- Max payout capacity calculation
+- Low bankroll alert thresholds
+- Edge cases (zero balance, large balance, concurrency)
+
+Issue: MAT-217
+Parent Issue: MAT-204 (cancelled)
+
+Run: python -m pytest tests/test_bankroll_monitoring.py -v -s
+"""
+
+import sys
+import os
+import pytest
+import asyncio
+from typing import Dict, Optional
+from decimal import Decimal
+
+# Add backend to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+import httpx
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Configuration
+# ═══════════════════════════════════════════════════════════════════
+
+TEST_NODE_URL = os.getenv("NODE_URL", "http://localhost:9052")
+TEST_API_KEY = os.getenv("API_KEY", "***")
+TEST_BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+HOUSE_ADDRESS = os.getenv("HOUSE_ADDRESS", "3WyrB3D5AMpyEc88UJ7FpdsBMXAZKwzQzkKeDbAQVfXytDPgxF26")
+COINFLIP_NFT_ID = os.getenv("COINFLIP_NFT_ID", "b0a111d06ccf32fa10c6b36f615233212bc725d8707575ccacc0c02267b27332")
+
+# Currency conversion
+NANO_ERG_PER_ERG = 1_000_000_000
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Helper Functions
+# ═══════════════════════════════════════════════════════════════════
+
+def nanoerg_to_erg(nanoerg: int) -> float:
+    """Convert nanoERG to ERG."""
+    return nanoerg / NANO_ERG_PER_ERG
+
+
+def erg_to_nanoerg(erg: float) -> int:
+    """Convert ERG to nanoERG."""
+    return int(erg * NANO_ERG_PER_ERG)
+
+
+async def get_bankroll_status() -> Dict:
+    """
+    Get bankroll status from backend API.
+
+    Returns:
+        Dict with keys: balance, exposure, available, pendingBets, lastUpdate
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{TEST_BACKEND_URL}/bankroll/status",
+            headers={"api_key": TEST_API_KEY},
+            timeout=10.0
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def get_house_wallet_balance(node_url: str = TEST_NODE_URL) -> int:
+    """
+    Get house wallet balance from Ergo node.
+
+    Returns:
+        Balance in nanoERG
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{node_url}/wallet/balances",
+            headers={"api_key": TEST_API_KEY}
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data[0]["balance"]  # nanoERG
+
+
+async def get_unspent_boxes_by_token(token_id: str, node_url: str = TEST_NODE_URL) -> list:
+    """
+    Get all unspent boxes containing a specific token.
+
+    Args:
+        token_id: Token ID (NFT or LP token)
+        node_url: Ergo node URL
+
+    Returns:
+        List of unspent box dictionaries
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{node_url}/blockchain/box/unspent/byTokenId/{token_id}"
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def calculate_exposure_from_boxes(boxes: list) -> int:
+    """
+    Calculate exposure from PendingBet box values.
+
+    Args:
+        boxes: List of unspent boxes
+
+    Returns:
+        Total exposure in nanoERG
+    """
+    return sum(box["value"] for box in boxes)
+
+
+async def get_box_by_id(box_id: str, node_url: str = TEST_NODE_URL) -> Optional[Dict]:
+    """
+    Get a box by its ID.
+
+    Returns:
+        Box dictionary or None if not found
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{node_url}/blockchain/box/byId/{box_id}",
+            headers={"api_key": TEST_API_KEY}
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════
+
+@pytest.fixture(scope="module")
+def backend_available():
+    """Check if backend is available."""
+    try:
+        asyncio.run(get_bankroll_status())
+        return True
+    except httpx.HTTPError:
+        pytest.skip("Backend API not available")
+
+
+@pytest.fixture(scope="module")
+def node_available():
+    """Check if Ergo node is available."""
+    try:
+        asyncio.run(get_house_wallet_balance())
+        return True
+    except httpx.HTTPError:
+        pytest.skip("Ergo node not available")
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Test Cases
+# ═══════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_bankroll_status_basic():
+    """
+    TC-001: Basic bankroll status endpoint.
+
+    Verify GET /bankroll/status returns all required fields.
+    """
+    data = await get_bankroll_status()
+
+    assert "balance" in data, "Missing 'balance' field"
+    assert "exposure" in data, "Missing 'exposure' field"
+    assert "available" in data, "Missing 'available' field"
+    assert "pendingBets" in data, "Missing 'pendingBets' field"
+    assert "lastUpdate" in data, "Missing 'lastUpdate' field"
+
+    # Type checks
+    assert isinstance(data["balance"], int), "balance should be int (nanoERG)"
+    assert isinstance(data["exposure"], int), "exposure should be int (nanoERG)"
+    assert isinstance(data["available"], int), "available should be int (nanoERG)"
+    assert isinstance(data["pendingBets"], int), "pendingBets should be int"
+
+    print(f"Balance: {nanoerg_to_erg(data['balance'])} ERG")
+    print(f"Exposure: {nanoerg_to_erg(data['exposure'])} ERG")
+    print(f"Available: {nanoerg_to_erg(data['available'])} ERG")
+    print(f"Pending Bets: {data['pendingBets']}")
+    print(f"Last Update: {data['lastUpdate']}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available", "node_available"])
+async def test_bankroll_balance_accuracy():
+    """
+    TC-002: Balance accuracy - matches node API.
+
+    Verify bankroll status balance matches Ergo node wallet balance.
+    """
+    # Get balance from bankroll API
+    bankroll_data = await get_bankroll_status()
+    bankroll_balance = bankroll_data["balance"]
+
+    # Get balance directly from node
+    node_balance = await get_house_wallet_balance()
+
+    assert bankroll_balance == node_balance, (
+        f"Balance mismatch: API={nanoerg_to_erg(bankroll_balance)} ERG, "
+        f"Node={nanoerg_to_erg(node_balance)} ERG"
+    )
+
+    print(f"Balance matches: {nanoerg_to_erg(bankroll_balance)} ERG")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_exposure_empty_state():
+    """
+    TC-003: Exposure calculation - empty state.
+
+    Verify exposure=0 and available=balance when no pending bets.
+    """
+    data = await get_bankroll_status()
+
+    # If there are no pending bets, verify exposure and available
+    if data["pendingBets"] == 0:
+        assert data["exposure"] == 0, "Exposure should be 0 with no pending bets"
+        assert data["available"] == data["balance"], (
+            "Available should equal balance with no exposure"
+        )
+    else:
+        pytest.skip("Pending bets exist, skipping empty state test")
+
+    print(f"Empty state verified: exposure=0, available={nanoerg_to_erg(data['available'])} ERG")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available", "node_available"])
+async def test_exposure_on_chain_verification():
+    """
+    TC-007: On-chain balance verification.
+
+    Verify exposure matches sum of PendingBet box values on-chain.
+    """
+    # Get data from API
+    bankroll_data = await get_bankroll_status()
+    api_exposure = bankroll_data["exposure"]
+    api_pending_count = bankroll_data["pendingBets"]
+
+    # Get PendingBet boxes from node
+    boxes = await get_unspent_boxes_by_token(COINFLIP_NFT_ID)
+    on_chain_exposure = await calculate_exposure_from_boxes(boxes)
+
+    assert len(boxes) == api_pending_count, (
+        f"Pending bet count mismatch: API={api_pending_count}, "
+        f"Node={len(boxes)}"
+    )
+
+    assert api_exposure == on_chain_exposure, (
+        f"Exposure mismatch: API={nanoerg_to_erg(api_exposure)} ERG, "
+        f"Node={nanoerg_to_erg(on_chain_exposure)} ERG"
+    )
+
+    print(f"Exposure verified: {nanoerg_to_erg(api_exposure)} ERG ({api_pending_count} bets)")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_available_balance_calculation():
+    """
+    TC-006: Available balance calculation.
+
+    Verify available = balance - exposure.
+    """
+    data = await get_bankroll_status()
+
+    expected_available = data["balance"] - data["exposure"]
+    actual_available = data["available"]
+
+    assert actual_available == expected_available, (
+        f"Available calculation incorrect: expected={nanoerg_to_erg(expected_available)} ERG, "
+        f"actual={nanoerg_to_erg(actual_available)} ERG"
+    )
+
+    print(f"Available balance: {nanoerg_to_erg(actual_available)} ERG")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_api_response_format():
+    """
+    Verify API response format and data types.
+    """
+    data = await get_bankroll_status()
+
+    # Verify response is JSON
+    assert isinstance(data, dict), "Response should be a JSON object"
+
+    # Verify all fields are present
+    required_fields = ["balance", "exposure", "available", "pendingBets", "lastUpdate"]
+    for field in required_fields:
+        assert field in data, f"Missing required field: {field}"
+
+    # Verify numeric fields are non-negative
+    assert data["balance"] >= 0, "Balance should be non-negative"
+    assert data["exposure"] >= 0, "Exposure should be non-negative"
+    assert data["pendingBets"] >= 0, "Pending bets count should be non-negative"
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_data_freshness():
+    """
+    Verify lastUpdate timestamp is recent (within 10 seconds).
+    """
+    from datetime import datetime, timedelta
+
+    data = await get_bankroll_status()
+
+    last_update_str = data["lastUpdate"]
+    last_update = datetime.fromisoformat(last_update_str.replace("Z", "+00:00"))
+    now = datetime.utcnow()
+
+    age = now - last_update
+    max_age = timedelta(seconds=10)
+
+    assert age <= max_age, (
+        f"Data is stale: age={age.total_seconds()}s, max=10s"
+    )
+
+    print(f"Data freshness: {age.total_seconds():.2f}s old")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_concurrent_requests():
+    """
+    TC-011: Concurrent requests - data consistency.
+
+    Verify multiple concurrent requests return consistent data.
+    """
+    # Make 10 concurrent requests
+    tasks = [get_bankroll_status() for _ in range(10)]
+    results = await asyncio.gather(*tasks)
+
+    # All results should be identical (within the same update window)
+    first_result = results[0]
+    for i, result in enumerate(results[1:], 1):
+        assert result == first_result, (
+            f"Concurrent request {i} returned different data"
+        )
+
+    print(f"Concurrent requests: {len(results)} consistent responses")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_large_values_handling():
+    """
+    TC-010: Large balance scenario.
+
+    Verify calculations work correctly with large values (100k+ ERG).
+    """
+    data = await get_bankroll_status()
+
+    # Even if balance is small, verify no overflow issues
+    balance = data["balance"]
+    exposure = data["exposure"]
+    available = data["available"]
+
+    # Verify available calculation doesn't underflow
+    assert available >= 0, "Available should never be negative"
+
+    # For large balances, verify precision
+    if balance > erg_to_nanoerg(100000):
+        print(f"Large balance test: {nanoerg_to_erg(balance)} ERG")
+    else:
+        print(f"Test with current balance: {nanoerg_to_erg(balance)} ERG")
+
+
+@pytest.mark.asyncio
+@pytest.mark.depends(on=["backend_available"])
+async def test_exposure_bounds():
+    """
+    Verify exposure is bounded by balance and pending bet count.
+    """
+    data = await get_bankroll_status()
+
+    # Exposure cannot exceed balance
+    assert data["exposure"] <= data["balance"], (
+        f"Exposure ({nanoerg_to_erg(data['exposure'])} ERG) cannot exceed "
+        f"balance ({nanoerg_to_erg(data['balance'])} ERG)"
+    )
+
+    # Exposure should be reasonable per pending bet (sanity check)
+    if data["pendingBets"] > 0:
+        avg_bet = data["exposure"] / data["pendingBets"]
+        # Each bet should be at least 0.01 ERG
+        assert avg_bet >= erg_to_nanoerg(0.01), (
+            f"Average bet too small: {nanoerg_to_erg(avg_bet)} ERG"
+        )
+        # Each bet should be at most 10,000 ERG (sanity)
+        assert avg_bet <= erg_to_nanoerg(10000), (
+            f"Average bet too large: {nanoerg_to_erg(avg_bet)} ERG"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Integration Tests (require manual bet placement)
+# ═══════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_exposure_increases_on_bet():
+    """
+    TC-003: Exposure increases when bet is placed.
+
+    This test requires manual intervention or automated bet placement.
+    """
+    # Record initial state
+    initial_data = await get_bankroll_status()
+    initial_exposure = initial_data["exposure"]
+    initial_pending = initial_data["pendingBets"]
+
+    # MANUAL STEP: Place a bet (e.g., 1 ERG) using the frontend
+    print("\n" + "="*70)
+    print("MANUAL STEP REQUIRED:")
+    print("1. Place a coinflip bet (e.g., 1 ERG) using the frontend")
+    print("2. Do NOT reveal the bet")
+    print("3. Press Enter to continue...")
+    print("="*70 + "\n")
+    input("Press Enter after placing bet...")
+
+    # Check updated state
+    updated_data = await get_bankroll_status()
+    updated_exposure = updated_data["exposure"]
+    updated_pending = updated_data["pendingBets"]
+
+    # Verify exposure increased
+    assert updated_exposure > initial_exposure, (
+        f"Exposure should increase after placing bet"
+    )
+
+    # Verify pending bets count increased
+    assert updated_pending == initial_pending + 1, (
+        f"Pending bets count should increase by 1"
+    )
+
+    print(f"Exposure increased: {nanoerg_to_erg(initial_exposure)} -> "
+          f"{nanoerg_to_erg(updated_exposure)} ERG")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_exposure_decreases_on_bet_resolution():
+    """
+    TC-005: Exposure decreases when bet is resolved.
+
+    This test requires manual intervention.
+    """
+    # Record initial state (should have pending bets)
+    initial_data = await get_bankroll_status()
+    initial_exposure = initial_data["exposure"]
+    initial_pending = initial_data["pendingBets"]
+
+    assert initial_pending > 0, (
+        "This test requires at least one pending bet. Place a bet first."
+    )
+
+    # MANUAL STEP: Reveal and resolve a bet
+    print("\n" + "="*70)
+    print("MANUAL STEP REQUIRED:")
+    print("1. Reveal one of the pending bets")
+    print("2. Wait for bet resolution")
+    print("3. Press Enter to continue...")
+    print("="*70 + "\n")
+    input("Press Enter after bet resolution...")
+
+    # Check updated state
+    updated_data = await get_bankroll_status()
+    updated_exposure = updated_data["exposure"]
+    updated_pending = updated_data["pendingBets"]
+
+    # Verify exposure decreased
+    assert updated_exposure < initial_exposure, (
+        f"Exposure should decrease after bet resolution"
+    )
+
+    # Verify pending bets count decreased
+    assert updated_pending == initial_pending - 1, (
+        f"Pending bets count should decrease by 1"
+    )
+
+    print(f"Exposure decreased: {nanoerg_to_erg(initial_exposure)} -> "
+          f"{nanoerg_to_erg(updated_exposure)} ERG")
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Run Tests
+# ═══════════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    # Run basic tests (no integration tests)
+    pytest.main([__file__, "-v", "-s", "-m", "not integration"])

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,39 @@
+"""
+Test Utilities Package
+
+Helper modules for DuckPools E2E tests.
+"""
+
+from .bankroll_helpers import (
+    nanoerg_to_erg,
+    erg_to_nanoerg,
+    fetch_bankroll_status,
+    fetch_house_wallet_balance,
+    fetch_unspent_boxes_by_token,
+    fetch_box_by_id,
+    calculate_exposure_from_boxes,
+    calculate_available_balance,
+    verify_balance_accuracy,
+    verify_exposure_accuracy,
+    get_bankroll_alerts,
+    stress_test_bankroll_endpoint,
+    format_erg_amount,
+    validate_bankroll_data
+)
+
+__all__ = [
+    "nanoerg_to_erg",
+    "erg_to_nanoerg",
+    "fetch_bankroll_status",
+    "fetch_house_wallet_balance",
+    "fetch_unspent_boxes_by_token",
+    "fetch_box_by_id",
+    "calculate_exposure_from_boxes",
+    "calculate_available_balance",
+    "verify_balance_accuracy",
+    "verify_exposure_accuracy",
+    "get_bankroll_alerts",
+    "stress_test_bankroll_endpoint",
+    "format_erg_amount",
+    "validate_bankroll_data"
+]

--- a/tests/utils/bankroll_helpers.py
+++ b/tests/utils/bankroll_helpers.py
@@ -1,0 +1,406 @@
+"""
+Bankroll Monitoring Test Utilities
+
+Helper functions for testing the bankroll monitoring service.
+"""
+
+import asyncio
+import httpx
+from typing import Dict, List, Optional
+from decimal import Decimal
+
+
+# Currency constants
+NANO_ERG_PER_ERG = 1_000_000_000
+
+
+def nanoerg_to_erg(nanoerg: int) -> float:
+    """Convert nanoERG to ERG."""
+    return nanoerg / NANO_ERG_PER_ERG
+
+
+def erg_to_nanoerg(erg: float) -> int:
+    """Convert ERG to nanoERG."""
+    return int(erg * NANO_ERG_PER_ERG)
+
+
+async def fetch_bankroll_status(
+    backend_url: str,
+    api_key: str
+) -> Dict:
+    """
+    Fetch bankroll status from backend API.
+
+    Args:
+        backend_url: Backend API URL
+        api_key: API authentication key
+
+    Returns:
+        Dictionary with bankroll metrics
+
+    Raises:
+        httpx.HTTPError: If request fails
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{backend_url}/bankroll/status",
+            headers={"api_key": api_key},
+            timeout=10.0
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def fetch_house_wallet_balance(
+    node_url: str,
+    wallet_address: Optional[str] = None,
+    api_key: str = "***"
+) -> int:
+    """
+    Fetch house wallet balance from Ergo node.
+
+    Args:
+        node_url: Ergo node URL
+        wallet_address: House wallet address (optional, if not provided uses default)
+        api_key: API key for node authentication
+
+    Returns:
+        Balance in nanoERG
+
+    Raises:
+        httpx.HTTPError: If request fails
+    """
+    async with httpx.AsyncClient() as client:
+        # If address provided, use UTXO by address endpoint
+        # Otherwise use wallet balances endpoint
+        if wallet_address:
+            response = await client.get(
+                f"{node_url}/utxo/byAddress/{wallet_address}",
+                headers={"api_key": api_key}
+            )
+            response.raise_for_status()
+            boxes = response.json()
+            return sum(box["value"] for box in boxes)
+        else:
+            response = await client.get(
+                f"{node_url}/wallet/balances",
+                headers={"api_key": api_key}
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data[0]["balance"]
+
+
+async def fetch_unspent_boxes_by_token(
+    node_url: str,
+    token_id: str,
+    api_key: str = "***"
+) -> List[Dict]:
+    """
+    Fetch all unspent boxes containing a specific token.
+
+    Args:
+        node_url: Ergo node URL
+        token_id: Token ID (NFT or LP token)
+        api_key: API key for node authentication
+
+    Returns:
+        List of unspent box dictionaries
+
+    Raises:
+        httpx.HTTPError: If request fails
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{node_url}/blockchain/box/unspent/byTokenId/{token_id}"
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def fetch_box_by_id(
+    box_id: str,
+    node_url: str,
+    api_key: str = "***"
+) -> Optional[Dict]:
+    """
+    Fetch a box by its ID.
+
+    Args:
+        box_id: Box ID (base64 or hex string)
+        node_url: Ergo node URL
+        api_key: API key for node authentication
+
+    Returns:
+        Box dictionary or None if not found
+
+    Raises:
+        httpx.HTTPError: If request fails (except 404)
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{node_url}/blockchain/box/byId/{box_id}",
+            headers={"api_key": api_key}
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+
+def calculate_exposure_from_boxes(boxes: List[Dict]) -> int:
+    """
+    Calculate total exposure from PendingBet box values.
+
+    Args:
+        boxes: List of box dictionaries
+
+    Returns:
+        Total exposure in nanoERG
+    """
+    return sum(box["value"] for box in boxes)
+
+
+def calculate_available_balance(balance: int, exposure: int) -> int:
+    """
+    Calculate available balance.
+
+    Args:
+        balance: Total balance in nanoERG
+        exposure: Total exposure in nanoERG
+
+    Returns:
+        Available balance in nanoERG
+    """
+    return balance - exposure
+
+
+async def verify_balance_accuracy(
+    backend_url: str,
+    node_url: str,
+    api_key: str
+) -> tuple[bool, str]:
+    """
+    Verify that backend balance matches node balance.
+
+    Args:
+        backend_url: Backend API URL
+        node_url: Ergo node URL
+        api_key: API key
+
+    Returns:
+        Tuple of (is_accurate, message)
+    """
+    try:
+        bankroll_data = await fetch_bankroll_status(backend_url, api_key)
+        node_balance = await fetch_house_wallet_balance(node_url, api_key=api_key)
+
+        backend_balance = bankroll_data["balance"]
+
+        if backend_balance == node_balance:
+            return True, (
+                f"Balance accurate: {nanoerg_to_erg(backend_balance)} ERG"
+            )
+        else:
+            diff = abs(backend_balance - node_balance)
+            return False, (
+                f"Balance mismatch: Backend={nanoerg_to_erg(backend_balance)} ERG, "
+                f"Node={nanoerg_to_erg(node_balance)} ERG, "
+                f"Diff={nanoerg_to_erg(diff)} ERG"
+            )
+    except Exception as e:
+        return False, f"Balance verification failed: {str(e)}"
+
+
+async def verify_exposure_accuracy(
+    backend_url: str,
+    node_url: str,
+    token_id: str,
+    api_key: str
+) -> tuple[bool, str]:
+    """
+    Verify that backend exposure matches on-chain exposure.
+
+    Args:
+        backend_url: Backend API URL
+        node_url: Ergo node URL
+        token_id: Coinflip NFT ID
+        api_key: API key
+
+    Returns:
+        Tuple of (is_accurate, message)
+    """
+    try:
+        bankroll_data = await fetch_bankroll_status(backend_url, api_key)
+        boxes = await fetch_unspent_boxes_by_token(node_url, token_id, api_key)
+        on_chain_exposure = calculate_exposure_from_boxes(boxes)
+
+        backend_exposure = bankroll_data["exposure"]
+        backend_pending = bankroll_data["pendingBets"]
+
+        if backend_exposure == on_chain_exposure:
+            if len(boxes) == backend_pending:
+                return True, (
+                    f"Exposure accurate: {nanoerg_to_erg(backend_exposure)} ERG "
+                    f"({backend_pending} bets)"
+                )
+            else:
+                return False, (
+                    f"Exposure matches but count mismatch: "
+                    f"Backend pending={backend_pending}, "
+                    f"Node boxes={len(boxes)}"
+                )
+        else:
+            diff = abs(backend_exposure - on_chain_exposure)
+            return False, (
+                f"Exposure mismatch: Backend={nanoerg_to_erg(backend_exposure)} ERG, "
+                f"Node={nanoerg_to_erg(on_chain_exposure)} ERG, "
+                f"Diff={nanoerg_to_erg(diff)} ERG"
+            )
+    except Exception as e:
+        return False, f"Exposure verification failed: {str(e)}"
+
+
+async def get_bankroll_alerts(
+    backend_url: str,
+    api_key: str
+) -> List[Dict]:
+    """
+    Get current bankroll alerts.
+
+    Args:
+        backend_url: Backend API URL
+        api_key: API key
+
+    Returns:
+        List of active alerts
+
+    Raises:
+        httpx.HTTPError: If request fails
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{backend_url}/bankroll/alerts",
+            headers={"api_key": api_key},
+            timeout=10.0
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def stress_test_bankroll_endpoint(
+    backend_url: str,
+    api_key: str,
+    num_requests: int = 100
+) -> Dict:
+    """
+    Stress test the bankroll status endpoint with concurrent requests.
+
+    Args:
+        backend_url: Backend API URL
+        api_key: API key
+        num_requests: Number of concurrent requests
+
+    Returns:
+        Dictionary with test results:
+            - success_count: Number of successful requests
+            - failure_count: Number of failed requests
+            - avg_response_time: Average response time in ms
+            - max_response_time: Max response time in ms
+            - min_response_time: Min response time in ms
+    """
+    import time
+
+    async def make_request():
+        start = time.time()
+        try:
+            await fetch_bankroll_status(backend_url, api_key)
+            return True, (time.time() - start) * 1000
+        except Exception:
+            return False, (time.time() - start) * 1000
+
+    tasks = [make_request() for _ in range(num_requests)]
+    results = await asyncio.gather(*tasks)
+
+    success_count = sum(1 for success, _ in results if success)
+    failure_count = num_requests - success_count
+
+    response_times = [rt for _, rt in results if rt is not None]
+    avg_response_time = sum(response_times) / len(response_times)
+    max_response_time = max(response_times)
+    min_response_time = min(response_times)
+
+    return {
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "avg_response_time": avg_response_time,
+        "max_response_time": max_response_time,
+        "min_response_time": min_response_time
+    }
+
+
+def format_erg_amount(nanoerg: int, decimals: int = 2) -> str:
+    """
+    Format nanoERG amount as a human-readable ERG string.
+
+    Args:
+        nanoerg: Amount in nanoERG
+        decimals: Number of decimal places
+
+    Returns:
+        Formatted string (e.g., "1.23 ERG")
+    """
+    erg = nanoerg / NANO_ERG_PER_ERG
+    return f"{erg:.{decimals}f} ERG"
+
+
+def validate_bankroll_data(data: Dict) -> tuple[bool, str]:
+    """
+    Validate bankroll status data structure and values.
+
+    Args:
+        data: Bankroll status dictionary
+
+    Returns:
+        Tuple of (is_valid, message)
+    """
+    required_fields = ["balance", "exposure", "available", "pendingBets", "lastUpdate"]
+
+    # Check all required fields present
+    missing_fields = [f for f in required_fields if f not in data]
+    if missing_fields:
+        return False, f"Missing fields: {', '.join(missing_fields)}"
+
+    # Check types
+    if not isinstance(data["balance"], int):
+        return False, "balance must be int"
+    if not isinstance(data["exposure"], int):
+        return False, "exposure must be int"
+    if not isinstance(data["available"], int):
+        return False, "available must be int"
+    if not isinstance(data["pendingBets"], int):
+        return False, "pendingBets must be int"
+
+    # Check non-negative
+    if data["balance"] < 0:
+        return False, "balance must be non-negative"
+    if data["exposure"] < 0:
+        return False, "exposure must be non-negative"
+    if data["available"] < 0:
+        return False, "available must be non-negative"
+    if data["pendingBets"] < 0:
+        return False, "pendingBets must be non-negative"
+
+    # Check calculations
+    expected_available = data["balance"] - data["exposure"]
+    if data["available"] != expected_available:
+        return False, (
+            f"available calculation incorrect: "
+            f"expected={expected_available}, actual={data['available']}"
+        )
+
+    # Check bounds
+    if data["exposure"] > data["balance"]:
+        return False, "exposure cannot exceed balance"
+
+    return True, "Bankroll data is valid"


### PR DESCRIPTION
## Summary

This PR adds a comprehensive E2E test plan for the DuckPools bankroll monitoring service (MAT-204). Since MAT-204 is currently cancelled, this test plan serves as a specification for when the bankroll monitoring feature is re-implemented.

## Changes

- Added detailed test plan in `tests/MAT-217_BANKROLL_TEST_PLAN.md` with 15 test cases
- Implemented test suite in `tests/test_bankroll_monitoring.py` with helper functions
- Created utility module in `tests/utils/bankroll_helpers.py` for common operations

## Test Coverage

The test plan covers:
- TC-001: Basic bankroll status endpoint functionality
- TC-002: Balance accuracy (matches on-chain data)
- TC-003: Exposure calculation (sum of unresolved bets)
- TC-004: Multiple bets exposure calculation
- TC-005: Exposure reduction on bet resolution
- TC-006: Max payout capacity calculation
- TC-007: On-chain balance verification
- TC-008: Low bankroll alert thresholds
- TC-009: Zero balance edge case
- TC-010: Large balance scenario (100k+ ERG)
- TC-011: Concurrent operations handling
- TC-012: API response caching
- TC-013: Real-time updates on bet events
- TC-014: Error handling (node API down)
- TC-015: Error handling (invalid token ID)

## Next Steps

This test plan is ready for execution once MAT-204 (bankroll monitoring service) is implemented. The tests can be run with:

```bash
python -m pytest tests/test_bankroll_monitoring.py -v -s
```

## Dependencies

This test plan depends on MAT-204 (bankroll monitoring service implementation), which is currently cancelled. Once MAT-204 is re-implemented, these tests can be executed to verify the bankroll monitoring functionality.

Closes #217