### PR TITLE
fix(security): SEC-B1 use hmac.compare_digest for API key comparison

### DIFF
--- a/backend/oracle_routes.py
+++ b/backend/oracle_routes.py
@@ -12,6 +12,7 @@ from typing import Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
+import hmac
 
 # Create router
 router = APIRouter(prefix="/api/oracle", tags=["oracle"])
@@ -43,7 +44,7 @@ async def verify_admin_api_key(request: Request):
             status_code=503,
             detail="Admin API key not configured on server. Set ADMIN_API_KEY env var."
         )
-    if not api_key or api_key != expected:
+    if not api_key or not hmac.compare_digest(api_key, expected):
         raise HTTPException(status_code=401, detail="Unauthorized: invalid or missing admin API key")
     return True
 

--- a/backend/ws_routes.py
+++ b/backend/ws_routes.py
@@ -365,7 +365,7 @@ async def ws_stats(request: Request):
     import os
     api_key = request.headers.get("X-Api-Key", "")
     expected = os.getenv("ADMIN_API_KEY", "")
-    if not expected or not api_key or api_key != expected:
+    if not expected or not api_key or not hmac.compare_digest(api_key, expected):
         raise HTTPException(status_code=401, detail="Admin API key required")
     ws_manager: ConnectionManager = request.app.state.ws_manager
     stats = ws_manager.get_stats()


### PR DESCRIPTION
## Timing Attack on API Key Comparison

Python's `!=` operator is not constant-time. An attacker can measure response times to extract API keys character by character.

## Fix
Both `/ws/stats` and `/oracle/switch` admin auth endpoints now use `hmac.compare_digest()` — already imported in ws_routes.py, added to oracle_routes.py.

## Regression
47/47 passed

Closes #102