### PR TITLE
543bd279: Implement VLQ encoder/decoder for Ergo values with full type coverage

### DIFF
--- a/backend/vlq_serializer.py
+++ b/backend/vlq_serializer.py
@@ -1,0 +1,465 @@
+"""
+DuckPools - VLQ Serializer for Ergo Values
+
+Implementation of VLQ (Variable-Length Quantity) encoder/decoder for Ergo register values
+with full type coverage including Int, Long, Coll[Byte], and SigmaProp.
+
+MAT-XXX: VLQ encoder/decoder for Ergo values with full type coverage
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
+from dataclasses import dataclass
+from enum import Enum
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+class ErgoType(str, Enum):
+    """Ergo value types for serialization."""
+    INT = "int"
+    LONG = "long"
+    COLL_BYTE = "coll_byte"
+    SIGMA_PROP = "sigma_prop"
+
+
+@dataclass
+class SerializedValue:
+    """Container for serialized Ergo value with metadata."""
+    value: str  # Hex-encoded serialized value
+    type: ErgoType
+    raw_value: Any
+
+
+class VLQError(Exception):
+    """Error raised during VLQ encoding/decoding."""
+    pass
+
+
+class VLQSerializer:
+    """
+    VLQ (Variable-Length Quantity) serializer for Ergo register values.
+    
+    Supports:
+    - Int: `02` + VLQ(zigzag_i32)
+    - Long: `04` + VLQ(zigzag_i64)
+    - Coll[Byte]: `0e` + `01` + VLQ(len) + hex
+    - SigmaProp: `08cd`+33-byte compressed PK
+    """
+    
+    # Type tags for Ergo values
+    INT_TAG = "02"
+    LONG_TAG = "04"
+    COLL_BYTE_TAG = "0e"
+    SIGMA_PROP_TAG = "08cd"
+    
+    # Coll[Byte] element type tag
+    COLL_BYTE_ELEM_TAG = "01"
+    
+    @classmethod
+    def _zigzag_encode_32(cls, value: int) -> int:
+        """Zigzag encode a 32-bit signed integer."""
+        return (value << 1) ^ (value >> 31)
+    
+    @classmethod
+    def _zigzag_decode_32(cls, value: int) -> int:
+        """Zigzag decode a 32-bit signed integer."""
+        return (value >> 1) ^ -(value & 1)
+    
+    @classmethod
+    def _zigzag_encode_64(cls, value: int) -> int:
+        """Zigzag encode a 64-bit signed integer."""
+        return (value << 1) ^ (value >> 63)
+    
+    @classmethod
+    def _zigzag_decode_64(cls, value: int) -> int:
+        """Zigzag decode a 64-bit signed integer."""
+        return (value >> 1) ^ -(value & 1)
+    
+    @classmethod
+    def _encode_vlq(cls, value: int) -> str:
+        """
+        Encode an integer using VLQ (Variable-Length Quantity).
+        
+        Args:
+            value: The integer to encode
+            
+        Returns:
+            Hex-encoded VLQ string
+        """
+        if value == 0:
+            return "00"
+        
+        hex_digits = []
+        while value > 0:
+            # Take 7 least significant bits
+            digit = value & 0x7f
+            value >>= 7
+            
+            # Set high bit if more digits follow
+            if value > 0:
+                digit |= 0x80
+            
+            hex_digits.append(f"{digit:02x}")
+        
+        return "".join(hex_digits)
+    
+    @classmethod
+    def _decode_vlq(cls, hex_str: str) -> int:
+        """
+        Decode a VLQ (Variable-Length Quantity) hex string.
+        
+        Args:
+            hex_str: Hex-encoded VLQ string
+            
+        Returns:
+            Decoded integer value
+        """
+        value = 0
+        shift = 0
+        
+        # Convert hex to bytes
+        try:
+            bytes_data = bytes.fromhex(hex_str)
+        except ValueError as e:
+            raise VLQError(f"Invalid hex string: {hex_str}") from e
+        
+        for byte in bytes_data:
+            # Extract 7 bits
+            value |= (byte & 0x7f) << shift
+            shift += 7
+            
+            # Check if this is the last byte
+            if not (byte & 0x80):
+                break
+        
+        return value
+    
+    @classmethod
+    def serialize_int(cls, value: int) -> SerializedValue:
+        """
+        Serialize an Int value: `02` + VLQ(zigzag_i32)
+        
+        Args:
+            value: 32-bit signed integer
+            
+        Returns:
+            SerializedValue with hex-encoded result
+        """
+        # Validate 32-bit range
+        if value < -2147483648 or value > 2147483647:
+            raise VLQError(f"Int value out of 32-bit range: {value}")
+        
+        # Zigzag encode
+        zigzag = cls._zigzag_encode_32(value)
+        
+        # VLQ encode
+        vlq_hex = cls._encode_vlq(zigzag)
+        
+        # Add type tag
+        serialized = cls.INT_TAG + vlq_hex
+        
+        return SerializedValue(
+            value=serialized,
+            type=ErgoType.INT,
+            raw_value=value
+        )
+    
+    @classmethod
+    def deserialize_int(cls, hex_str: str) -> int:
+        """
+        Deserialize an Int value: `02` + VLQ(zigzag_i32)
+        
+        Args:
+            hex_str: Hex-encoded Int value
+            
+        Returns:
+            Original 32-bit signed integer
+        """
+        if not hex_str.startswith(cls.INT_TAG):
+            raise VLQError(f"Invalid Int type tag: {hex_str}")
+        
+        # Remove type tag
+        vlq_hex = hex_str[2:]
+        
+        # VLQ decode
+        zigzag = cls._decode_vlq(vlq_hex)
+        
+        # Zigzag decode
+        value = cls._zigzag_decode_32(zigzag)
+        
+        return value
+    
+    @classmethod
+    def serialize_long(cls, value: int) -> SerializedValue:
+        """
+        Serialize a Long value: `04` + VLQ(zigzag_i64)
+        
+        Args:
+            value: 64-bit signed integer
+            
+        Returns:
+            SerializedValue with hex-encoded result
+        """
+        # Validate 64-bit range
+        if value < -9223372036854775808 or value > 9223372036854775807:
+            raise VLQError(f"Long value out of 64-bit range: {value}")
+        
+        # Zigzag encode
+        zigzag = cls._zigzag_encode_64(value)
+        
+        # VLQ encode
+        vlq_hex = cls._encode_vlq(zigzag)
+        
+        # Add type tag
+        serialized = cls.LONG_TAG + vlq_hex
+        
+        return SerializedValue(
+            value=serialized,
+            type=ErgoType.LONG,
+            raw_value=value
+        )
+    
+    @classmethod
+    def deserialize_long(cls, hex_str: str) -> int:
+        """
+        Deserialize a Long value: `04` + VLQ(zigzag_i64)
+        
+        Args:
+            hex_str: Hex-encoded Long value
+            
+        Returns:
+            Original 64-bit signed integer
+        """
+        if not hex_str.startswith(cls.LONG_TAG):
+            raise VLQError(f"Invalid Long type tag: {hex_str}")
+        
+        # Remove type tag
+        vlq_hex = hex_str[2:]
+        
+        # VLQ decode
+        zigzag = cls._decode_vlq(vlq_hex)
+        
+        # Zigzag decode
+        value = cls._zigzag_decode_64(zigzag)
+        
+        return value
+    
+    @classmethod
+    def serialize_coll_byte(cls, data: bytes, sbyte_included: bool = False) -> SerializedValue:
+        """
+        Serialize a Coll[Byte] value: `0e` + `01` + VLQ(len) + hex
+        
+        Args:
+            data: Byte array to serialize
+            sbyte_included: If True, assume data already includes SByte (0x01)
+            
+        Returns:
+            SerializedValue with hex-encoded result
+        """
+        if not isinstance(data, bytes):
+            raise VLQError(f"Coll[Byte] requires bytes input, got {type(data)}")
+        
+        # Convert bytes to hex
+        hex_data = data.hex()
+        
+        # Build serialized value
+        if sbyte_included:
+            # Format: 0e + VLQ(len) + hex (already includes 0x01)
+            serialized = cls.COLL_BYTE_TAG + cls._encode_vlq(len(data)) + hex_data
+        else:
+            # Format: 0e + 01 + VLQ(len) + hex
+            serialized = cls.COLL_BYTE_TAG + cls.COLL_BYTE_ELEM_TAG + cls._encode_vlq(len(data)) + hex_data
+        
+        return SerializedValue(
+            value=serialized,
+            type=ErgoType.COLL_BYTE,
+            raw_value=data
+        )
+    
+    @classmethod
+    def deserialize_coll_byte(cls, hex_str: str) -> bytes:
+        """
+        Deserialize a Coll[Byte] value: `0e` + `01` + VLQ(len) + hex
+        
+        Args:
+            hex_str: Hex-encoded Coll[Byte] value
+            
+        Returns:
+            Original byte array
+        """
+        if not hex_str.startswith(cls.COLL_BYTE_TAG):
+            raise VLQError(f"Invalid Coll[Byte] type tag: {hex_str}")
+        
+        # Remove type tag
+        remaining = hex_str[2:]
+        
+        # Check if SByte is present
+        if remaining.startswith(cls.COLL_BYTE_ELEM_TAG):
+            # Format: 0e + 01 + VLQ(len) + hex
+            sbyte = remaining[0:2]
+            if sbyte != cls.COLL_BYTE_ELEM_TAG:
+                raise VLQError(f"Invalid Coll[Byte] SByte: {sbyte}")
+            remaining = remaining[2:]
+        
+        # Decode length
+        try:
+            # Find the end of VLQ (first byte without high bit set)
+            length_hex = ""
+            for i in range(0, len(remaining), 2):
+                if i + 2 > len(remaining):
+                    break
+                byte = int(remaining[i:i+2], 16)
+                length_hex += remaining[i:i+2]
+                if not (byte & 0x80):
+                    break
+            
+            length = cls._decode_vlq(length_hex)
+            data_hex = remaining[len(length_hex):]
+            
+            # Validate length
+            if len(data_hex) // 2 != length:
+                raise VLQError(f"Coll[Byte] length mismatch: expected {length}, got {len(data_hex) // 2}")
+            
+            # Convert hex to bytes
+            data = bytes.fromhex(data_hex)
+            return data
+            
+        except Exception as e:
+            raise VLQError(f"Failed to deserialize Coll[Byte]: {e}") from e
+    
+    @classmethod
+    def serialize_sigma_prop(cls, public_key: bytes) -> SerializedValue:
+        """
+        Serialize a SigmaProp value: `08cd` + 33-byte compressed PK
+        
+        Args:
+            public_key: 33-byte compressed public key
+            
+        Returns:
+            SerializedValue with hex-encoded result
+        """
+        if len(public_key) != 33:
+            raise VLQError(f"SigmaProp requires 33-byte public key, got {len(public_key)} bytes")
+        
+        # Add type tag and convert PK to hex
+        serialized = cls.SIGMA_PROP_TAG + public_key.hex()
+        
+        return SerializedValue(
+            value=serialized,
+            type=ErgoType.SIGMA_PROP,
+            raw_value=public_key
+        )
+    
+    @classmethod
+    def deserialize_sigma_prop(cls, hex_str: str) -> bytes:
+        """
+        Deserialize a SigmaProp value: `08cd` + 33-byte compressed PK
+        
+        Args:
+            hex_str: Hex-encoded SigmaProp value
+            
+        Returns:
+            Original 33-byte compressed public key
+        """
+        if not hex_str.startswith(cls.SIGMA_PROP_TAG):
+            raise VLQError(f"Invalid SigmaProp type tag: {hex_str}")
+        
+        # Remove type tag
+        pk_hex = hex_str[4:]
+        
+        # Validate length (33 bytes = 66 hex chars)
+        if len(pk_hex) != 66:
+            raise VLQError(f"SigmaProp requires 66 hex chars (33 bytes), got {len(pk_hex)}")
+        
+        # Convert hex to bytes
+        try:
+            return bytes.fromhex(pk_hex)
+        except ValueError as e:
+            raise VLQError(f"Invalid SigmaProp hex: {pk_hex}") from e
+    
+    @classmethod
+    def serialize_value(cls, value: Any, value_type: ErgoType) -> SerializedValue:
+        """
+        Generic serialization method that dispatches to appropriate serializer.
+        
+        Args:
+            value: Value to serialize
+            value_type: Type of the value
+            
+        Returns:
+            SerializedValue with hex-encoded result
+        """
+        try:
+            if value_type == ErgoType.INT:
+                return cls.serialize_int(int(value))
+            elif value_type == ErgoType.LONG:
+                return cls.serialize_long(int(value))
+            elif value_type == ErgoType.COLL_BYTE:
+                if isinstance(value, str):
+                    # Assume hex string
+                    return cls.serialize_coll_byte(bytes.fromhex(value))
+                elif isinstance(value, bytes):
+                    return cls.serialize_coll_byte(value)
+                else:
+                    raise VLQError(f"Unsupported Coll[Byte] input type: {type(value)}")
+            elif value_type == ErgoType.SIGMA_PROP:
+                if isinstance(value, str):
+                    # Assume hex string
+                    return cls.serialize_sigma_prop(bytes.fromhex(value))
+                elif isinstance(value, bytes):
+                    return cls.serialize_sigma_prop(value)
+                else:
+                    raise VLQError(f"Unsupported SigmaProp input type: {type(value)}")
+            else:
+                raise VLQError(f"Unsupported ErgoType: {value_type}")
+        except Exception as e:
+            raise VLQError(f"Failed to serialize {value_type} value: {e}") from e
+    
+    @classmethod
+    def deserialize_value(cls, hex_str: str) -> Any:
+        """
+        Generic deserialization method that detects type from hex string.
+        
+        Args:
+            hex_str: Hex-encoded Ergo value
+            
+        Returns:
+            Deserialized value
+        """
+        try:
+            if hex_str.startswith(cls.INT_TAG):
+                return cls.deserialize_int(hex_str)
+            elif hex_str.startswith(cls.LONG_TAG):
+                return cls.deserialize_long(hex_str)
+            elif hex_str.startswith(cls.COLL_BYTE_TAG):
+                return cls.deserialize_coll_byte(hex_str)
+            elif hex_str.startswith(cls.SIGMA_PROP_TAG):
+                return cls.deserialize_sigma_prop(hex_str)
+            else:
+                raise VLQError(f"Unknown Ergo value type: {hex_str[:4]}...")
+        except Exception as e:
+            raise VLQError(f"Failed to deserialize value: {e}") from e
+    
+    @classmethod
+    def detect_type(cls, hex_str: str) -> Optional[ErgoType]:
+        """
+        Detect the type of a hex-encoded Ergo value.
+        
+        Args:
+            hex_str: Hex-encoded Ergo value
+            
+        Returns:
+            Detected ErgoType or None if unknown
+        """
+        if hex_str.startswith(cls.INT_TAG):
+            return ErgoType.INT
+        elif hex_str.startswith(cls.LONG_TAG):
+            return ErgoType.LONG
+        elif hex_str.startswith(cls.COLL_BYTE_TAG):
+            return ErgoType.COLL_BYTE
+        elif hex_str.startswith(cls.SIGMA_PROP_TAG):
+            return ErgoType.SIGMA_PROP
+        else:
+            return None

--- a/tests/test_vlq_serializer.py
+++ b/tests/test_vlq_serializer.py
@@ -1,0 +1,288 @@
+"""
+Tests for VLQ Serializer implementation.
+
+Tests encoding/decoding for all Ergo value types:
+- Int: `02` + VLQ(zigzag_i32)
+- Long: `04` + VLQ(zigzag_i64)
+- Coll[Byte]: `0e` + `01` + VLQ(len) + hex
+- SigmaProp: `08cd`+33-byte compressed PK
+"""
+
+import pytest
+from backend.vlq_serializer import (
+    VLQSerializer, 
+    ErgoType, 
+    SerializedValue, 
+    VLQError
+)
+
+
+class TestVLQSerializer:
+    """Test cases for VLQSerializer class."""
+    
+    def test_int_serialization(self):
+        """Test Int serialization and deserialization."""
+        test_cases = [
+            0, 1, -1, 10, -10, 2147483647, -2147483648, 42, -42
+        ]
+        
+        for value in test_cases:
+            # Serialize
+            serialized = VLQSerializer.serialize_int(value)
+            
+            # Check type and structure
+            assert serialized.type == ErgoType.INT
+            assert serialized.value.startswith("02")
+            assert serialized.raw_value == value
+            
+            # Deserialize
+            deserialized = VLQSerializer.deserialize_int(serialized.value)
+            assert deserialized == value
+    
+    def test_int_overflow(self):
+        """Test Int overflow detection."""
+        # Test 64-bit values that should fail for 32-bit Int
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_int(2147483648)  # 2^31
+        
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_int(-2147483649)  # -2^31 - 1
+    
+    def test_int_invalid_tag(self):
+        """Test Int deserialization with invalid type tag."""
+        with pytest.raises(VLQError):
+            VLQSerializer.deserialize_int("04")  # Long tag instead of Int
+    
+    def test_long_serialization(self):
+        """Test Long serialization and deserialization."""
+        test_cases = [
+            0, 1, -1, 10, -10, 2147483648, -2147483649, 
+            9223372036854775807, -9223372036854775808, 42, -42
+        ]
+        
+        for value in test_cases:
+            # Serialize
+            serialized = VLQSerializer.serialize_long(value)
+            
+            # Check type and structure
+            assert serialized.type == ErgoType.LONG
+            assert serialized.value.startswith("04")
+            assert serialized.raw_value == value
+            
+            # Deserialize
+            deserialized = VLQSerializer.deserialize_long(serialized.value)
+            assert deserialized == value
+    
+    def test_long_overflow(self):
+        """Test Long overflow detection."""
+        # Test values outside 64-bit range
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_long(9223372036854775808)  # 2^63
+        
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_long(-9223372036854775809)  # -2^63 - 1
+    
+    def test_long_invalid_tag(self):
+        """Test Long deserialization with invalid type tag."""
+        with pytest.raises(VLQError):
+            VLQSerializer.deserialize_long("02")  # Int tag instead of Long
+    
+    def test_coll_byte_serialization(self):
+        """Test Coll[Byte] serialization and deserialization."""
+        test_cases = [
+            b"",  # Empty bytes
+            b"hello",  # ASCII
+            bytes(range(256)),  # All byte values
+            b"\x00\x01\x02\x03",  # Binary data
+            b"\xff\xfe\xfd\xfc",  # High byte values
+        ]
+        
+        for data in test_cases:
+            # Serialize
+            serialized = VLQSerializer.serialize_coll_byte(data)
+            
+            # Check type and structure
+            assert serialized.type == ErgoType.COLL_BYTE
+            assert serialized.value.startswith("0e01")
+            assert serialized.raw_value == data
+            
+            # Deserialize
+            deserialized = VLQSerializer.deserialize_coll_byte(serialized.value)
+            assert deserialized == data
+    
+    def test_coll_byte_sbyte_included(self):
+        """Test Coll[Byte] serialization with SByte already included."""
+        data = b"hello"
+        
+        # Serialize with SByte already in data
+        data_with_sbyte = b"\x01" + data
+        serialized = VLQSerializer.serialize_coll_byte(data_with_sbyte, sbyte_included=True)
+        
+        # Should not include extra SByte
+        assert serialized.value.startswith("0e")
+        # Check that the SByte is only present once
+        assert serialized.value[2:4] != "01"  # No extra SByte
+        
+        # Deserialize should work
+        deserialized = VLQSerializer.deserialize_coll_byte(serialized.value)
+        assert deserialized == data_with_sbyte
+    
+    def test_coll_byte_invalid_input(self):
+        """Test Coll[Byte] with invalid input type."""
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_coll_byte("not bytes")  # String instead of bytes
+    
+    def test_coll_byte_invalid_tag(self):
+        """Test Coll[Byte] deserialization with invalid type tag."""
+        with pytest.raises(VLQError):
+            VLQSerializer.deserialize_coll_byte("02")  # Int tag instead of Coll[Byte]
+    
+    def test_sigma_prop_serialization(self):
+        """Test SigmaProp serialization and deserialization."""
+        # Test with 33-byte public keys
+        test_pks = [
+            bytes([0x02] + [i % 256 for i in range(32)]),  # 33 bytes
+            bytes([0x03] + [0xff] * 32),  # All 0xff after first byte
+            bytes(range(33)),  # 33 bytes with values 0-32
+        ]
+        
+        for pk in test_pks:
+            # Serialize
+            serialized = VLQSerializer.serialize_sigma_prop(pk)
+            
+            # Check type and structure
+            assert serialized.type == ErgoType.SIGMA_PROP
+            assert serialized.value.startswith("08cd")
+            assert serialized.raw_value == pk
+            
+            # Deserialize
+            deserialized = VLQSerializer.deserialize_sigma_prop(serialized.value)
+            assert deserialized == pk
+    
+    def test_sigma_prop_invalid_length(self):
+        """Test SigmaProp with invalid public key length."""
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_sigma_prop(b"too_short")  # Less than 33 bytes
+        
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_sigma_prop(b"too_long_for_33_bytes")  # More than 33 bytes
+    
+    def test_sigma_prop_invalid_tag(self):
+        """Test SigmaProp deserialization with invalid type tag."""
+        with pytest.raises(VLQError):
+            VLQSerializer.deserialize_sigma_prop("02")  # Int tag instead of SigmaProp
+    
+    def test_sigma_prop_invalid_hex(self):
+        """Test SigmaProp deserialization with invalid hex."""
+        with pytest.raises(VLQError):
+            VLQSerializer.deserialize_sigma_prop("08cdinvalidhex")  # Invalid hex
+    
+    def test_generic_serialization(self):
+        """Test generic serialization and deserialization."""
+        test_cases = [
+            (42, ErgoType.INT),
+            (-42, ErgoType.INT),
+            (2147483648, ErgoType.LONG),
+            (-2147483649, ErgoType.LONG),
+            ("aabbccdd", ErgoType.COLL_BYTE),
+            (b"aabbccdd", ErgoType.COLL_BYTE),
+            ("02" + "00" * 32, ErgoType.SIGMA_PROP),  # 33-byte hex PK
+            (bytes([0x02] + [0] * 32), ErgoType.SIGMA_PROP),  # 33-byte PK
+        ]
+        
+        for value, value_type in test_cases:
+            # Serialize
+            serialized = VLQSerializer.serialize_value(value, value_type)
+            
+            # Check type
+            assert serialized.type == value_type
+            
+            # Deserialize
+            deserialized = VLQSerializer.deserialize_value(serialized.value)
+            
+            # Compare
+            if isinstance(value, str) and value_type in [ErgoType.COLL_BYTE, ErgoType.SIGMA_PROP]:
+                # Convert hex string to bytes for comparison
+                expected = bytes.fromhex(value)
+                assert deserialized == expected
+            else:
+                assert deserialized == value
+    
+    def test_generic_serialization_error(self):
+        """Test generic serialization with unsupported type."""
+        with pytest.raises(VLQError):
+            VLQSerializer.serialize_value("value", "unsupported_type")
+    
+    def test_type_detection(self):
+        """Test type detection from hex strings."""
+        test_cases = [
+            ("0200", ErgoType.INT),
+            ("0400", ErgoType.LONG),
+            ("0e0100", ErgoType.COLL_BYTE),
+            ("08cd" + "00" * 33, ErgoType.SIGMA_PROP),
+            ("unknown", None),
+        ]
+        
+        for hex_str, expected_type in test_cases:
+            detected_type = VLQSerializer.detect_type(hex_str)
+            assert detected_type == expected_type
+    
+    def test_vlq_edge_cases(self):
+        """Test VLQ encoding/decoding edge cases."""
+        # Test zero
+        assert VLQSerializer._encode_vlq(0) == "00"
+        assert VLQSerializer._decode_vlq("00") == 0
+        
+        # Test single byte
+        assert VLQSerializer._encode_vlq(1) == "01"
+        assert VLQSerializer._decode_vlq("01") == 1
+        
+        # Test multi-byte
+        assert VLQSerializer._encode_vlq(128) == "8001"
+        assert VLQSerializer._decode_vlq("8001") == 128
+        
+        # Test large value
+        large_value = 0x12345678
+        encoded = VLQSerializer._encode_vlq(large_value)
+        decoded = VLQSerializer._decode_vlq(encoded)
+        assert decoded == large_value
+    
+    def test_zigzag_encoding(self):
+        """Test zigzag encoding/decoding."""
+        test_cases = [
+            (0, 0),
+            (1, 2),
+            (-1, 1),
+            (2, 4),
+            (-2, 3),
+            (42, 84),
+            (-42, 83),
+            (2147483647, 4294967294),  # Max 32-bit positive
+            (-2147483648, 4294967295),  # Min 32-bit negative
+        ]
+        
+        for original, zigzag in test_cases:
+            # 32-bit
+            assert VLQSerializer._zigzag_encode_32(original) == zigzag
+            assert VLQSerializer._zigzag_decode_32(zigzag) == original
+            
+            # 64-bit (same for small values)
+            assert VLQSerializer._zigzag_encode_64(original) == zigzag
+            assert VLQSerializer._zigzag_decode_64(zigzag) == original
+    
+    def test_real_world_examples(self):
+        """Test with real-world examples from Ergo documentation."""
+        # Int examples from ARCHITECTURE.md
+        assert VLQSerializer.serialize_int(0).value == "0200"
+        assert VLQSerializer.serialize_int(1).value == "0202"
+        assert VLQSerializer.serialize_int(10).value == "0214"
+        
+        # Coll[Byte] example (32 bytes)
+        data_32_bytes = bytes(range(32))
+        serialized = VLQSerializer.serialize_coll_byte(data_32_bytes)
+        assert serialized.value.startswith("0e01")
+        assert len(serialized.value) == 2 + 2 + 2 + 64  # 0e + 01 + VLQ(len) + 32*2 hex chars
+        
+        # Long examples
+        assert VLQSerializer.serialize_long(0).value == "0400"
+        assert VLQSerializer.serialize_long(1).value == "0402"


### PR DESCRIPTION
## Summary

This PR implements a comprehensive VLQ (Variable-Length Quantity) encoder/decoder for Ergo blockchain register values with full type coverage as requested in issue #543bd279.

### Features Implemented:

1. **Int Serialization**:  + VLQ(zigzag_i32)
   - Supports all 32-bit signed integers
   - Includes overflow detection
   - Zigzag encoding for efficient storage of signed values

2. **Long Serialization**:  + VLQ(zigzag_i64)
   - Supports all 64-bit signed integers
   - Includes overflow detection
   - Zigzag encoding for efficient storage of signed values

3. **Coll[Byte] Serialization**:  +  + VLQ(len) + hex
   - Handles both formats: with and without SByte prefix
   - Automatic length encoding with VLQ
   - Robust error handling for invalid inputs

4. **SigmaProp Serialization**:  + 33-byte compressed PK
   - Validates 33-byte public key requirement
   - Proper type tag prefix
   - Hex encoding/decoding support

### Implementation Details:

- **VLQ Encoding**: Efficient variable-length encoding for integers
- **Zigzag Encoding**: Optimized encoding for signed integers
- **Type Detection**: Automatic type detection from hex strings
- **Generic Interface**: Unified  and  methods
- **Error Handling**: Comprehensive error messages and validation
- **Testing**: 20+ test cases covering edge cases and real-world examples

### Files Added:

- : Main implementation
- : Comprehensive test suite

### Testing:

All tests pass, including:
- Basic serialization/deserialization
- Edge cases (zero, max/min values)
- Error handling (invalid inputs, overflow)
- Real-world examples from Ergo documentation
- Type detection
- Zigzag encoding verification

## Testing

============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0 -- /Library/Developer/CommandLineTools/usr/bin/python3
cachedir: .pytest_cache
rootdir: /Users/n1ur0/projects/worktrees/vlq-encoder-decoder-impl-543bd279
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.2.0, cov-7.1.0
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 20 items

tests/test_vlq_serializer.py::TestVLQSerializer::test_int_serialization PASSED [  5%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_int_overflow PASSED [ 10%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_int_invalid_tag PASSED [ 15%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_long_serialization PASSED [ 20%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_long_overflow PASSED [ 25%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_long_invalid_tag PASSED [ 30%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_coll_byte_serialization PASSED [ 35%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_coll_byte_sbyte_included PASSED [ 40%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_coll_byte_invalid_input PASSED [ 45%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_coll_byte_invalid_tag PASSED [ 50%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_sigma_prop_serialization PASSED [ 55%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_sigma_prop_invalid_length PASSED [ 60%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_sigma_prop_invalid_tag PASSED [ 65%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_sigma_prop_invalid_hex PASSED [ 70%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_generic_serialization PASSED [ 75%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_generic_serialization_error PASSED [ 80%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_type_detection PASSED [ 85%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_vlq_edge_cases PASSED [ 90%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_zigzag_encoding PASSED [ 95%]
tests/test_vlq_serializer.py::TestVLQSerializer::test_real_world_examples PASSED [100%]

============================== 20 passed in 0.02s ==============================

Closes #543bd279