### PR TITLE
fix: resolve pre-existing CI failures blocking all open PRs

### DIFF
--- a/frontend/src/components/games/DiceGame.tsx
+++ b/frontend/src/components/games/DiceGame.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, TouchEvent } from 'react';
 import { useWallet } from '../../contexts/WalletContext';
-import { generateDiceCommit, computeDiceRng, isDiceWin, getDiceMultiplier, DICE_MIN_TARGET, DICE_MAX_TARGET, DICE_DEFAULT_TARGET } from '../../utils/dice';
+import { generateDiceCommit, getDiceMultiplier, DICE_MIN_TARGET, DICE_MAX_TARGET, DICE_DEFAULT_TARGET } from '../../utils/dice';
 import { ergToNanoErg, formatErg } from '../../utils/ergo';
 import { buildApiUrl } from '../../utils/network';
 import './DiceGame.css';

--- a/frontend/src/utils/network.ts
+++ b/frontend/src/utils/network.ts
@@ -1,18 +1,18 @@
 // Network and API utilities
 
-const API_BASE = process.env.VITE_API_ENDPOINT || '';
+const API_BASE = import.meta.env.VITE_API_ENDPOINT || '';
 
 export function buildApiUrl(endpoint: string): string {
-  if (process.env.NODE_ENV === 'development') return `/api${endpoint}`;
+  if (import.meta.env.DEV) return `/api${endpoint}`;
   return `${API_BASE}${endpoint}`;
 }
 
 export function getNodeUrl(): string {
-  return process.env.VITE_NODE_URL || 'https://api-testnet.ergoplatform.com';
+  return import.meta.env.VITE_NODE_URL || 'https://api-testnet.ergoplatform.com';
 }
 
 export function getExpectedNetworkType(): 'testnet' | 'mainnet' {
-  return (process.env.VITE_NETWORK as 'testnet' | 'mainnet') || 'testnet';
+  return (import.meta.env.VITE_NETWORK as 'testnet' | 'mainnet') || 'testnet';
 }
 
 /**

--- a/frontend/src/wallet/useErgoWallet.ts
+++ b/frontend/src/wallet/useErgoWallet.ts
@@ -28,7 +28,7 @@ import { getExpectedNetworkType, getNetworkFromAddress } from '../utils/network'
 import { getWalletConnection, waitForConnector, getWalletInfo } from './adapters';
 
 // Use a simple flag for logging - in production this would be false
-const isDev = process.env.NODE_ENV === 'development';
+const isDev = import.meta.env.DEV;
 const log = isDev ? console : { log: () => {}, warn: () => {}, error: () => {} };
 
 // ─── Helpers ────────────────────────────────────────────────────

--- a/frontend/src/wallet/useWalletSessionPersistence.ts
+++ b/frontend/src/wallet/useWalletSessionPersistence.ts
@@ -35,7 +35,7 @@ const SESSION_KEY = 'duckpools-wallet-session';
 const SESSION_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // Use a simple flag for logging - in production this would be false
-const isDev = process.env.NODE_ENV === 'development';
+const isDev = import.meta.env.DEV;
 const log = isDev ? console : { log: () => {}, warn: () => {}, error: () => {} };
 
 /**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ filterwarnings = [
 addopts = "-v --tb=short"
 asyncio_mode = "auto"
 
-[tool.pytest.coverage.run]
+[tool.coverage.run]
 source = ["backend", "sdk"]
 omit = ["tests/*", "*/node_modules/*", "*/__pycache__/*"]
 
-[tool.pytest.coverage.report]
+[tool.coverage.report]
 fail_under = 50
 show_missing = true


### PR DESCRIPTION
## Summary

Fixes 5 pre-existing issues on `main` that cause Frontend Build, Docker Build, and Security Regression CI checks to fail on ALL open PRs.

### Changes

| File | Issue | Fix |
|------|-------|-----|
| `frontend/src/components/games/DiceGame.tsx` | Unused imports `computeDiceRng`, `isDiceWin` (TS6133) | Removed unused imports |
| `frontend/src/utils/network.ts` | `process.env` not available in Vite (TS2580) | Replaced with `import.meta.env` |
| `frontend/src/wallet/useErgoWallet.ts` | Same `process.env` issue | Replaced `process.env.NODE_ENV` with `import.meta.env.DEV` |
| `frontend/src/wallet/useWalletSessionPersistence.ts` | Same `process.env` issue | Same fix |
| `pyproject.toml` | `[tool.pytest.coverage.*]` conflicts with `[tool.pytest.ini_options]` | Moved to `[tool.coverage.*]` |

### Why `process.env` -> `import.meta.env`
Vite does not inject `process.env`. Environment variables prefixed with `VITE_` are available via `import.meta.env`. `import.meta.env.DEV` is a Vite built-in for development detection.

### Why `[tool.pytest.coverage.*]` -> `[tool.coverage.*]`
Pytest treats `[tool.pytest.coverage.run]` as a subtable of `[tool.pytest]`, which conflicts with `[tool.pytest.ini_options]` (both define pytest config). Coverage config belongs under `[tool.coverage]`.

### Impact
This unblocks PRs #118, #128, #129, #130 which all have red CI from these same pre-existing issues.