### PR TITLE
fix(db): correct AsyncSession class_ and make DATABASE_URL configurable

### DIFF
--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,6 +1,8 @@
 """Database module for DuckPools bankroll management."""
 
-from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+import os
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy import String, Numeric, BigInteger, DateTime, Boolean, Integer, Index, Text
 from datetime import datetime
@@ -16,8 +18,15 @@ class Base(DeclarativeBase):
 
 
 # Async engine configuration
+# DATABASE_URL must be set via environment variable or .env file.
+# Fallback is a local dev default (PostgreSQL on standard port).
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+asyncpg://duckpools:duckpools@localhost:5432/duckpools",
+)
+
 engine = create_async_engine(
-    "postgresql+asyncpg://user:password@localhost:5432/duckpools",
+    DATABASE_URL,
     echo=False,
     pool_pre_ping=True,
     pool_size=10,
@@ -26,7 +35,7 @@ engine = create_async_engine(
 
 AsyncSessionLocal = async_sessionmaker(
     engine,
-    class_=async_sessionmaker,
+    class_=AsyncSession,
     expire_on_commit=False,
 )
 


### PR DESCRIPTION
## Senior Infrastructure Fix

### Problem
1. `async_sessionmaker(class_=async_sessionmaker)` passes the factory class instead of the session class. Every `get_db()` call would create a broken session instance, silently breaking all bankroll endpoints.
2. Database URL was hardcoded as `user:password` with no env var override.

### Fix
- `class_=AsyncSession` (correct session class)
- `DATABASE_URL` reads from `os.getenv()` with safe dev default
- Added `AsyncSession` to imports

### Files changed
- `backend/app/db/__init__.py` (12 insertions, 3 deletions)

### Risk
Low — this is a configuration fix. The sessionmaker was creating instances of the wrong class before; now it creates proper AsyncSession instances.