### PR TITLE
DESIGN-1: Fix 'tails' color inconsistency across components

### DIFF
--- a/frontend/src/components/BetForm.css
+++ b/frontend/src/components/BetForm.css
@@ -189,15 +189,15 @@
 }
 
 .bf-choice-btn--tails {
-  background: linear-gradient(135deg, rgba(99, 179, 237, 0.15), rgba(99, 179, 237, 0.05));
-  color: #63b3ed;
-  border-color: rgba(99, 179, 237, 0.2);
+  background: linear-gradient(135deg, var(--accent-tails-subtle), rgba(99, 179, 237, 0.05));
+  color: var(--accent-tails);
+  border-color: var(--accent-tails-subtle);
 }
 
 .bf-choice-btn--tails:hover {
   background: linear-gradient(135deg, rgba(99, 179, 237, 0.25), rgba(99, 179, 237, 0.1));
-  border-color: #63b3ed;
-  box-shadow: 0 0 20px rgba(99, 179, 237, 0.15);
+  border-color: var(--accent-tails);
+  box-shadow: 0 0 20px var(--accent-tails-subtle);
 }
 
 .bf-choice-btn--selected {
@@ -211,7 +211,7 @@
 }
 
 .bf-choice-btn--tails.bf-choice-btn--selected {
-  border-color: #63b3ed;
+  border-color: var(--accent-tails);
   box-shadow: 0 0 24px rgba(99, 179, 237, 0.2);
   background: linear-gradient(135deg, rgba(99, 179, 237, 0.3), rgba(99, 179, 237, 0.15));
 }

--- a/frontend/src/components/GameHistory.css
+++ b/frontend/src/components/GameHistory.css
@@ -138,8 +138,8 @@
 }
 
 .gh-choice-badge--tails {
-  background: rgba(99, 179, 237, 0.12);
-  color: #63b3ed;
+  background: var(--accent-tails-subtle);
+  color: var(--accent-tails);
 }
 
 /* ── Outcome colors ─────────────────────────────── */

--- a/frontend/src/components/animations/CoinFlip.tsx
+++ b/frontend/src/components/animations/CoinFlip.tsx
@@ -45,7 +45,7 @@ const CoinFlip: React.FC<CoinFlipProps> = ({
   const getCoinColor = () => {
     if (isFlipping) return 'var(--accent-gold)';
     if (result === 'heads') return 'var(--accent-gold)';
-    if (result === 'tails') return 'var(--accent-blue, #3b82f6)';
+    if (result === 'tails') return 'var(--accent-tails)';
     return 'var(--accent-gold)';
   };
 


### PR DESCRIPTION
## Summary\n\nFixes the inconsistent "tails" color across components. CoinFlip was using #3b82f6 while BetForm and GameHistory were using #63b3ed. This standardizes all components to use the CSS design token var(--accent-tails) which is set to #63b3ed.\n\n## Changes\n\n- Updated CoinFlip.tsx to use var(--accent-tails) instead of var(--accent-blue, #3b82f6)\n- Updated BetForm.css to use var(--accent-tails) and var(--accent-tails-subtle) instead of hardcoded values\n- Updated GameHistory.css to use var(--accent-tails) and var(--accent-tails-subtle) instead of hardcoded values\n\nCloses #d93ffb7d-4c9e-4d00-99c6-77d33ba8f9f8\n\n## Testing\n\n- Verify all components display the same tails color (#63b3ed)\n- Check that hover and selected states maintain consistent styling\n- Ensure design tokens are properly applied