### PR TITLE
DESIGN-1: Fix tails color inconsistency across components

### DIFF
--- a/frontend/src/components/BetForm.css
+++ b/frontend/src/components/BetForm.css
@@ -189,15 +189,15 @@
 }
 
 .bf-choice-btn--tails {
-  background: linear-gradient(135deg, var(--accent-tails-subtle), rgba(99, 179, 237, 0.05));
-  color: var(--accent-tails);
-  border-color: var(--accent-tails-subtle);
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-blue)dd);
+  color: var(--accent-blue);
+  border-color: var(--accent-blue);
 }
 
 .bf-choice-btn--tails:hover {
-  background: linear-gradient(135deg, rgba(99, 179, 237, 0.25), rgba(99, 179, 237, 0.1));
-  border-color: var(--accent-tails);
-  box-shadow: 0 0 20px var(--accent-tails-subtle);
+  background: rgba(59, 130, 246, 0.1);
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 20px var(--accent-blue);
 }
 
 .bf-choice-btn--selected {
@@ -211,9 +211,8 @@
 }
 
 .bf-choice-btn--tails.bf-choice-btn--selected {
-  border-color: var(--accent-tails);
-  box-shadow: 0 0 24px rgba(99, 179, 237, 0.2);
-  background: linear-gradient(135deg, rgba(99, 179, 237, 0.3), rgba(99, 179, 237, 0.15));
+  border-color: var(--accent-blue);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(59, 130, 246, 0.15));
 }
 
 /* ── Submit Button ─────────────────────────────── */

--- a/frontend/src/components/GameHistory.css
+++ b/frontend/src/components/GameHistory.css
@@ -138,8 +138,8 @@
 }
 
 .gh-choice-badge--tails {
-  background: var(--accent-tails-subtle);
-  color: var(--accent-tails);
+  background: var(--accent-blue);
+  color: var(--accent-blue);
 }
 
 /* ── Outcome colors ─────────────────────────────── */

--- a/frontend/src/components/animations/animations.css
+++ b/frontend/src/components/animations/animations.css
@@ -106,7 +106,7 @@
 }
 
 .coin--tails {
-  background: linear-gradient(135deg, var(--accent-tails), var(--accent-tails)dd);
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-blue)dd);
 }
 
 .coin--heads-flipping {


### PR DESCRIPTION
Fix the inconsistent tails color across components. Standardized all components to use accent-blue (#3b82f6) instead of the previous mix of accent-blue and accent-tails (#63b3ed).

Changes:
- CoinFlip: Updated animation to use accent-blue
- BetForm: Updated tails button styling to use accent-blue  
- GameHistory: Updated tails badge to use accent-blue
- All tails-related styling now uses the standardized color #3b82f6

Closes DESIGN-1