### PR TITLE
DESIGN-1: Fix 'tails' color inconsistency — standardize to #3b82f6

### DIFF
--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -33,10 +33,10 @@
   --accent-red-subtle: rgba(239, 68, 68, 0.15);
   --accent-blue: #3b82f6;
   --accent-purple: #8b5cf6;
-  --accent-tails: #63b3ed;
-  --accent-tails-light: #90cdf4;
-  --accent-tails-dark: #4299e1;
-  --accent-tails-subtle: rgba(99, 179, 237, 0.15);
+  --accent-tails: #3b82f6;
+  --accent-tails-light: #63b3ed;
+  --accent-tails-dark: #2563eb;
+  --accent-tails-subtle: rgba(59, 130, 246, 0.15);
 
   /* === Semantic Colors === */
   --color-success: #00ff88;


### PR DESCRIPTION
## Summary

Fixes the inconsistent "tails" color across components. CoinFlip uses #3b82f6 while BetForm and GameHistory use #63b3ed. Standardizes all components to use the same blue color.

## Changes Made

- Updated  CSS token from  to  to match 
- Updated related tokens: , , 
- Now all components (CoinFlip, BetForm, GameHistory) use consistent blue color for "tails"

## Testing

- Frontend builds successfully without errors
- All color references to  now resolve to consistent value
- Visual inspection shows uniform blue color across components

Closes DESIGN-1