### PR TITLE
DESIGN-1: Fix 'tails' color inconsistency — CoinFlip uses #3b82f6, BetForm/GameHistory use #63b3ed

### DIFF
--- a/frontend/src/components/BetForm.css
+++ b/frontend/src/components/BetForm.css
@@ -189,13 +189,13 @@
 }
 
 .bf-choice-btn--tails {
-  background: linear-gradient(135deg, var(--accent-tails-subtle), rgba(99, 179, 237, 0.05));
+  background: linear-gradient(135deg, var(--accent-tails-subtle), rgba(59, 130, 246, 0.05));
   color: var(--accent-tails);
   border-color: var(--accent-tails-subtle);
 }
 
 .bf-choice-btn--tails:hover {
-  background: linear-gradient(135deg, rgba(99, 179, 237, 0.25), rgba(99, 179, 237, 0.1));
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(59, 130, 246, 0.1));
   border-color: var(--accent-tails);
   box-shadow: 0 0 20px var(--accent-tails-subtle);
 }
@@ -212,8 +212,8 @@
 
 .bf-choice-btn--tails.bf-choice-btn--selected {
   border-color: var(--accent-tails);
-  box-shadow: 0 0 24px rgba(99, 179, 237, 0.2);
-  background: linear-gradient(135deg, rgba(99, 179, 237, 0.3), rgba(99, 179, 237, 0.15));
+  box-shadow: 0 0 24px rgba(59, 130, 246, 0.2);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(59, 130, 246, 0.15));
 }
 
 /* ── Submit Button ─────────────────────────────── */

--- a/frontend/src/components/ui/Toast.css
+++ b/frontend/src/components/ui/Toast.css
@@ -106,22 +106,22 @@
 
 /* Info - Blue theme */
 .toast--info {
-  background: rgba(99, 179, 237, 0.1);
-  border: 1px solid rgba(99, 179, 237, 0.3);
-  color: #63b3ed;
+  background: var(--accent-tails-subtle);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: var(--accent-blue);
 }
 
 .toast--info .toast__icon {
-  color: #63b3ed;
+  color: var(--accent-blue);
 }
 
 .toast--info .toast__close {
-  color: #63b3ed;
-  border-color: rgba(99, 179, 237, 0.3);
+  color: var(--accent-blue);
+  border-color: rgba(59, 130, 246, 0.3);
 }
 
 .toast--info .toast__close:hover {
-  background: rgba(99, 179, 237, 0.2);
+  background: rgba(59, 130, 246, 0.2);
 }
 
 /* ── Icon ─────────────────────────────────────────── */

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -34,7 +34,7 @@
   --accent-blue: #3b82f6;
   --accent-purple: #8b5cf6;
   --accent-tails: #3b82f6;
-  --accent-tails-light: #63b3ed;
+  --accent-tails-light: #3b82f6;
   --accent-tails-dark: #2563eb;
   --accent-tails-subtle: rgba(59, 130, 246, 0.15);
 


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Issue Reference
<!-- Link to the Matsuzaka issue this PR addresses -->
- Fixes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] Security

## Changes Made
<!-- List the key changes -->

## Testing
<!-- How was this tested? -->

## Checklist
- [ ] Code compiles without errors
- [ ] Tests pass
- [ ] No hardcoded secrets or keys
- [ ] Follows project conventions
