### PR TITLE
DESIGN-1: Fix tails color inconsistency across components

### DIFF
--- a/frontend/src/components/games/CoinFlipGame.css
+++ b/frontend/src/components/games/CoinFlipGame.css
@@ -76,7 +76,7 @@
 }
 
 .coinflip-result.tails {
-  color: var(--accent-blue, #3b82f6);
+  color: var(--accent-tails, #63b3ed);
 }
 
 @keyframes coinflip-result-appear {
@@ -276,14 +276,14 @@
 }
 
 .coinflip-choice-btn--tails {
-  border-color: rgba(59, 130, 246, 0.3);
+  border-color: rgba(99, 179, 237, 0.3);
 }
 
 .coinflip-choice-btn--tails:hover,
 .coinflip-choice-btn--tails.coinflip-choice-btn--selected {
-  background: rgba(59, 130, 246, 0.1);
-  border-color: var(--accent-blue, #3b82f6);
-  color: var(--accent-blue, #3b82f6);
+  background: rgba(99, 179, 237, 0.1);
+  border-color: var(--accent-tails, #63b3ed);
+  color: var(--accent-tails, #63b3ed);
 }
 
 .coinflip-choice-btn:active {

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -33,10 +33,10 @@
   --accent-red-subtle: rgba(239, 68, 68, 0.15);
   --accent-blue: #3b82f6;
   --accent-purple: #8b5cf6;
-  --accent-tails: #3b82f6;
-  --accent-tails-light: #63b3ed;
+  --accent-tails: #63b3ed;
+  --accent-tails-light: #93c5fd;
   --accent-tails-dark: #2563eb;
-  --accent-tails-subtle: rgba(59, 130, 246, 0.15);
+  --accent-tails-subtle: rgba(99, 179, 237, 0.15);
 
   /* === Semantic Colors === */
   --color-success: #00ff88;


### PR DESCRIPTION
## Summary

Fixed the inconsistent 'tails' color across components. CoinFlip was using #3b82f6 while BetForm and GameHistory were using #63b3ed. Now all components use the consistent --accent-tails color (#63b3ed).

## Changes Made
- Updated tokens.css: Set --accent-tails to #63b3ed (was #3b82f6)
- Updated --accent-tails-light to #93c5fd (was #63b3ed)  
- Updated --accent-tails-subtle to use new rgba value
- Updated CoinFlipGame.css to use --accent-tails instead of --accent-blue
- Updated all related rgba background/border colors

## Testing
- Verified that CoinFlip, BetForm, and GameHistory all now use the same tails color (#63b3ed)
- Checked that color variables resolve correctly in CSS
- Confirmed no breaking changes to other blue colors in the system

Closes #DESIGN-1