### PR TITLE
[MAT-157] Add off-chain-bot to development docker-compose and update documentation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -72,6 +72,16 @@ The Docker Compose setup includes:
 | frontend | 3000 | React Vite dev server |
 | off-chain-bot | - | Bot for bet resolution (no port exposure) |
 
+## Development Environment
+
+The Docker Compose setup includes all three services for development:
+
+- **backend-api**: FastAPI backend with hot-reload on port 8000
+- **frontend**: React Vite dev server with hot-reload on port 3000
+- **off-chain-bot**: Background bot for bet resolution (no port exposure)
+
+All services include health checks and hot-reload support for development.
+
 ## Accessing Services
 
 - **Frontend**: http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ docker compose down -v
   - `VITE_ERGO_NODE_URL`: Ergo node URL
   - `CHOKIDAR_USEPOLLING`: Enable file polling in Docker
 
+#### Off-chain Bot Service
+
+- **No Port Exposed**: Runs in background (no external access needed)
+- **Health Check**: Process monitoring
+- **Hot-Reload**: Enabled (code changes trigger restart)
+- **Environment Variables**:
+  - `NODE_ENV`: development
+  - `LOG_LEVEL`: DEBUG
+  - `ERGO_NODE_URL`: External Ergo node URL
+  - `ERGO_API_KEY`: Ergo node API key
+
 ### Production Builds
 
 To create optimized production builds:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,32 @@ services:
     depends_on:
       - backend-api  # Start backend first
 
-  
+  # Off-chain Bot Service
+  off-chain-bot:
+    build:
+      context: ./off-chain-bot
+      target: development  # Use development stage
+    container_name: duckpools-offchain-bot-dev
+    environment:
+      # Bot configuration (can be overridden in docker-compose.override.yml)
+      - NODE_ENV=development
+      - LOG_LEVEL=DEBUG
+      # Ergo node configuration (external)
+      - ERGO_NODE_URL=http://host.docker.internal:9052
+      - ERGO_API_KEY=blake2b256("hello")
+    volumes:
+      # Default volumes (can be extended in docker-compose.override.yml)
+      - ./off-chain-bot:/app
+    networks:
+      - coinflip-net
+    healthcheck:
+      test: ["CMD", "pgrep", "-f", "main.py"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+    depends_on:
+      - backend-api  # Start backend first
 
 # Network configuration (can be overridden in docker-compose.override.yml)
 networks:


### PR DESCRIPTION
## Summary\n\nCompletes the Docker setup for development environment by adding the off-chain-bot service to docker-compose.yml and updating documentation.\n\n## Changes Made\n\n1. Added off-chain-bot service to development docker-compose.yml with:\n   - Development target for hot-reload support\n   - Health check configuration\n   - Proper environment variables\n   - Volume mounts for code changes\n   - Dependency on backend-api service\n\n2. Updated README.md with:\n   - Added off-chain-bot service details\n   - Documented environment variables\n   - Clarified that it runs in background with no port exposure\n\n3. Updated DOCKER.md with:\n   - Added development environment section\n   - Clarified all three services are included in development\n\n## Testing\n\nThe Docker setup now includes all three services:\n- Backend API (FastAPI) with hot-reload on port 8000\n- Frontend (React) with hot-reload on port 3000\n- Off-chain Bot running in background\n\nAll services have health checks and hot-reload support for development.\n\nFixes MAT-157